### PR TITLE
chore: remove .DS_Store from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+# Ignore macOS .DS_Store files
+.DS_Store


### PR DESCRIPTION
.DS_Storeファイルは、macOSがフォルダの表示設定などを保存する為に自動的に生成する隠しファイルであり、これらは、プロジェクトのバージョン管理には必要ない為、Gitの管理から除外。