### PR TITLE
fix: sign out

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,3 +1,3 @@
 <h1>ホームページ</h1>
 <p>ようこそ、<%= current_user.email %>さん！</p>
-<%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
+<%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %>


### PR DESCRIPTION
◼︎signoutの際、DELETE ではなくGET として処理される問題の解消。
Turboがリンクに対してメソッドの実行を処理する為、link_to ヘルパー内の method: :delete オプションをdata: { turbo_method: :delete }に修正。