### PR TITLE
chore: specify ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ group :test do
 end
 
 gem "devise", "~> 4.9"
+ruby '3.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,5 +333,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
+RUBY VERSION
+   ruby 3.2.3p157
+
 BUNDLED WITH
    2.5.21


### PR DESCRIPTION
◼︎rubyバージョンの不一致が原因で、Herokuデプロイが失敗したため、gemfile内でrubyバージョンを指定