### PR TITLE
chore: modify production section

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -82,6 +82,4 @@ test:
 #
 production:
   <<: *default
-  database: myapp_production
-  username: myapp
-  password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
+  url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
◼︎データベースの接続先が未設定だった為、エラーが発生。

背景
・ローカルでDockerを使う場合、「db」という名前でデータベースサービスに接続しますが、Herokuではデータベース接続は自動で環境変数に設定され、HerokuのPostgreSQLを使う為の接続情報が提供されます。

解決方法
・config/database.ymlのproduction 環境の設定が DATABASE_URL 環境変数を使ってデータベースに接続するように設定。