### PR TITLE
fix: db conection error

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,17 +1,5 @@
 # PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
+
 default: &default
   adapter: postgresql
   encoding: unicode
@@ -22,63 +10,52 @@ default: &default
 development:
   <<: *default
   database: myapp_development
-  host: localhost
+  host: db
+  username: postgres
+  password: password
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: myapp
+  # When left blank, PostgreSQL will use the default role.
+  # This is the same name as the operating system user running Rails.
+  # username: myapp
 
   # The password associated with the PostgreSQL role (username).
-  #password:
+  # password:
 
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
+  # Connect on a TCP socket.
+  # Omitted by default since the client uses a domain socket that doesn't need configuration.
+  # host: localhost
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
-  #port: 5432
+  # port: 5432
 
   # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
+  # schema_search_path: myapp,sharedapp,public
 
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
+  # Minimum log levels, in increasing order: debug5, debug4, debug3, debug2, debug1, log, notice, warning, error, fatal, and panic
   # Defaults to warning.
-  #min_messages: notice
+  # min_messages: notice
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# Warning: The database defined as "test" will be erased and re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
   database: myapp_test
-  host: localhost
+  host: db
+  username: postgres
+  password: password
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
+# you never want to store sensitive information, like your database password, in your source code.
+# Instead, provide the password or a full connection URL as an environment variable when you boot the app.
+# If the connection URL is provided in the special DATABASE_URL environment variable,
+# Rails will automatically merge its configuration values on top of the values provided in this file.
+# Alternatively, you can specify a connection URL environment variable explicitly.
+
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
-#
+
 production:
   <<: *default
   url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
Dockerを使用している場合、コンテナ間で通信を行うために、hostにはデータベースのコンテナ名(db)を指定します。
これによりDockerが自動的にそのコンテナのIPアドレスを解決し、アプリがデータベースに接続されます。