### PR TITLE
feat: mailing

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,10 +77,21 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.mailgun.org",
+    port: 587,
+    domain: ENV['MAILGUN_DOMAIN'],
+    user_name: "postmaster@#{ENV['MAILGUN_DOMAIN']}",
+    password: ENV['MAILGUN_API_KEY'],
+    authentication: "plain",
+    enable_starttls_auto: true
+  }
+  config.action_mailer.default_url_options = { host: 'quiet-retreat-43609-63e9cfd4f8f2.herokuapp.com', protocol: 'https' }
 
-  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to false and ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'no-reply@quiet-retreat-43609-63e9cfd4f8f2.herokuapp.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
◼︎環境変数の設定 (APIキーとドメイン)
◼︎本番環境でメール送信がされるよう、config/environments/production.rbの設定変更
　ソースコードに直接記載を避ける為、ENV['MAILGUN_DOMAIN']やENV['MAILGUN_API_KEY']には、
　Herokuの環境変数を利用します。
◼︎Deviseの設定
　Deviseでメール認証を有効にするため、config.mailer_senderを適切なメールアドレスに設定します。