### PR TITLE
fix: db deploy error

### DIFF
--- a/db/migrate/20241123071638_create_simulations.rb
+++ b/db/migrate/20241123071638_create_simulations.rb
@@ -1,0 +1,11 @@
+class CreateSimulations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :simulations do |t|
+      t.references :user, foreign_key: true, null: false
+      t.decimal :inflation_rate, null: false
+      t.jsonb :income_data, null: false 
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
simulations_tableがscenarios_tableよりも先に作成される必要がある為、タイムスタンプを修正。