### PR TITLE
feat: add expens logic

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,16 +1,21 @@
 class ExpensesController < ApplicationController
+  before_action :authenticate_user!
+
   def index
-    @last_expense = Expense.last
+    @last_expense = current_user.expenses.last
     @expense = Expense.new
   end
 
   def create
     @expense = current_user.expenses.build(convert_repayment_date(expense_params))
     @expense.simulation = current_user.simulation
+
     if @expense.save
+      @expense.update_simulation_expense_data(current_user)
+      @last_expense = current_user.expenses.last
       respond_to_format
-      redirect_to expenses_path, notice: '費用が保存されました'
     else
+      @last_expense = @expense
       render_create_error
     end
   end
@@ -23,7 +28,6 @@ class ExpensesController < ApplicationController
 
   def convert_repayment_date(params)
     if params[:repayment_date].present?
-      # repayment_dateを年からDate型に変換
       params[:repayment_date] = Date.new(params[:repayment_date].to_i, 1, 1)
     end
     params
@@ -31,14 +35,13 @@ class ExpensesController < ApplicationController
 
   def respond_to_format
     respond_to do |format|
-      format.html { redirect_to expenses_path, notice: 'Expense was successfully created.' }
+      format.html { redirect_to expenses_path, notice: '費用が保存されました。' }
       format.turbo_stream
     end
   end
 
   def render_create_error
     flash.now[:error] = @expense.errors.full_messages.join(", ")
-    @last_expense = Income.last
     render :index
   end
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -4,9 +4,48 @@ class Expense < ApplicationRecord
 
   validates :user_id, presence: true
   validates :simulation_id, presence: true
-  validates :repayment_date, presence: true
+  
   validates :housing_expense, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  validates :living_expenses, presence: true,  numericality: { greater_than_or_equal_to: 0 }
-  validates :monthly_premiums, presence: true,  numericality: { greater_than_or_equal_to: 0 }
-  validates :other_expenses, presence: true,  numericality: { greater_than_or_equal_to: 0 }
+  validates :repayment_date, presence: true
+  validates :living_expenses, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :monthly_premiums, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :other_expenses, presence: true, numericality: { greater_than_or_equal_to: 0 }
+
+  def update_simulation_expense_data(current_user)
+    current_year = Date.today.year
+    retirement_date = current_user.incomes.order(created_at: :desc).first.retirement_date
+    expense_data = calculate_expenses(current_year, retirement_date)
+
+    simulation_record = current_user.simulation
+    if simulation_record
+      simulation_record.update(expense_data: expense_data)
+    else
+      errors.add(:simulation, "関連するシミュレーションが存在しません")
+    end
+  end
+
+  def calculate_expenses(current_year, retirement_date)
+    total_expense_per_month = housing_expense + living_expenses + monthly_premiums + other_expenses
+    expense_data = []
+
+    if repayment_date.nil?
+      # 住宅ローンがない場合
+      (current_year..retirement_date.year).each do |year|
+        yearly_expense = total_expense_per_month * 12 * -1
+        expense_data << { date: year, amount: yearly_expense }
+      end
+    else
+      # 住宅ローンがある場合
+      repayment_year = repayment_date.year.to_i
+      (current_year..retirement_date.year).each do |year|
+        if year <= repayment_year
+          yearly_expense = (housing_expense + living_expenses + monthly_premiums + other_expenses) * 12 * -1
+        else
+          yearly_expense = (living_expenses + monthly_premiums + other_expenses) * 12 * -1
+        end
+        expense_data << { date: year, amount: yearly_expense }
+      end
+    end
+    expense_data
+  end
 end

--- a/app/views/expenses/_expense.html.erb
+++ b/app/views/expenses/_expense.html.erb
@@ -1,8 +1,12 @@
 <p>前回保存されたデータ</p>
-<div id="<%= dom_id(expense) %>" class="row">
-  <p class="col">住居費（月額）※家賃またはローン：<%= expense.housing_expense %>万円</p>
-  <p class="col">住宅ローン完済時期：<%= expense.repayment_date %></p>
-  <p class="col">生活費（月額）：<%= expense.living_expenses %>万円</p>
-  <p class="col">保険費（月額）※貯蓄型保険は除く：<%= expense.monthly_premiums %>万円</p>
-  <p class="col">その他費用（月額）：<%= expense.other_expenses %>万円</p>
-</div>
+<% if expense.present? %>
+  <div id="<%= dom_id(expense) %>" class="row">
+    <p class="col">住居費（月額）※家賃またはローン：<%= expense.housing_expense %>万円</p>
+    <p class="col">住宅ローン完済時期：<%= expense.repayment_date %></p>
+    <p class="col">生活費（月額）：<%= expense.living_expenses %>万円</p>
+    <p class="col">保険費（月額）※貯蓄型保険は除く：<%= expense.monthly_premiums %>万円</p>
+    <p class="col">その他費用（月額）：<%= expense.other_expenses %>万円</p>
+  </div>
+<% else %>
+  <p>前回保存されたデータはありません。</p>
+<% end %>

--- a/app/views/expenses/create.turbo_stream.erb
+++ b/app/views/expenses/create.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= turbo_stream.append "expenses", partial: "expenses/expense", locals: { expense: @last_expense } %>
+<%= turbo_stream.replace "expenses", partial: "expenses/expense", locals: { expense: @last_expense } %>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="form-group">
     <%= f.label :repayment_date, '住宅ローン完済時期', class: 'form-label' %>
-    <%= f.select :repayment_date, options_for_select([['支払いなし', 0]] + (Date.today.year..(Date.today.year + 50)).map { |year| [year, year] }), {}, class: 'form-select' %>
+    <%= f.select :repayment_date, options_for_select([['支払いなし', nil]] + (Date.today.year..(Date.today.year + 50)).map { |year| [year, year] }), {}, class: 'form-select' %>
   </div>
   <div class="form-group">
     <%= f.label :living_expenses, '生活費（月額）', class: 'form-label' %>
@@ -27,6 +27,10 @@
 <% end %>
 <%= link_to '収入入力に戻る', incomes_path, class: 'btn btn-secondary', data: { turbo: true } %>
 
-<div id="incomes">
-  <%= render @last_expense if @last_expense.present? %>
+<div id="expenses">
+  <% if @last_expense %>
+    <%= render @last_expense %>
+  <% else %>
+    <p>No expense data available.</p>
+  <% end %>
 </div>

--- a/db/migrate/20241127063443_change_repayment_date_in_expenses.rb
+++ b/db/migrate/20241127063443_change_repayment_date_in_expenses.rb
@@ -1,0 +1,5 @@
+class ChangeRepaymentDateInExpenses < ActiveRecord::Migration[7.2]
+  def change
+    change_column :expenses, :repayment_date, :date, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_26_093350) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_27_063443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,7 +18,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_26_093350) do
     t.bigint "user_id", null: false
     t.bigint "simulation_id", null: false
     t.decimal "housing_expense", default: "0.0", null: false
-    t.date "repayment_date", default: -> { "CURRENT_DATE" }, null: false
+    t.date "repayment_date"
     t.decimal "living_expenses", default: "0.0", null: false
     t.decimal "monthly_premiums", default: "0.0", null: false
     t.decimal "other_expenses", default: "0.0", null: false


### PR DESCRIPTION
◼︎expenseモデルにexpense入力を元に計算した値をsimulationテーブルに保存するロジックを追加
◼︎ローン返済期間の選択で、「支払いなし」の場合はnilを指定するように編集
◼︎上記のnil許容に伴い、expenseのrepayment_dateのnull: falseの解除