### PR TITLE
feat: add rogic for update life_event_data

### DIFF
--- a/app/controllers/life_events_controller.rb
+++ b/app/controllers/life_events_controller.rb
@@ -24,6 +24,16 @@ class LifeEventsController < ApplicationController
     end
   end
 
+  def update_life_event_data
+    simulation_id = params[:simulation_id]
+  
+    if LifeEvent.update_simulation_data(simulation_id)
+      redirect_to life_events_path, notice: 'LifeEventDataが更新されました。'
+    else
+      redirect_to life_events_path, alert: 'LifeEventDataの更新に失敗しました。'
+    end
+  end
+
   private
 
   def life_event_params

--- a/app/models/life_event.rb
+++ b/app/models/life_event.rb
@@ -12,4 +12,23 @@ class LifeEvent < ApplicationRecord
   validates :title, presence: true
   validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :payment_span, presence: true
+
+  # ビジネスロジック：life_event_dataを更新
+  def self.update_simulation_data(simulation_id)
+    # 指定されたsimulation_idに関連するlife_eventsを取得
+    life_events = LifeEvent.where(simulation_id: simulation_id)
+
+    # 年ごとにamountを集計（event_dateの年を抽出）
+    year_amounts = life_events.group_by { |event| event.event_date.year }.transform_values do |events|
+      events.sum { |event| -event.amount } # マイナス値で格納
+    end
+
+    # ハッシュ配列に変換
+    life_event_data = year_amounts.map do |year, amount|
+      { date: year, amount: amount } # dateを年のみの形式にする
+    end
+
+    # simulationテーブルを直接更新
+    Simulation.find(simulation_id).update(life_event_data: life_event_data)
+  end
 end

--- a/app/views/life_events/index.html.erb
+++ b/app/views/life_events/index.html.erb
@@ -34,6 +34,9 @@
   </div>
 <% end %>
 
+<%= button_to 'simu更新（button）', update_life_event_data_life_events_path(simulation_id: current_user.simulation.id), method: :post, class: 'btn btn-primary' %>
+<%= link_to 'エラーsimu(linl_to)', update_life_event_data_life_events_path(simulation_id: current_user.simulation.id), method: :post, class: 'btn btn-success', data: { turbo_stream: true } %>
+<%= link_to 'エラーが起きるボタン', update_life_event_data_life_events_path(simulation_id: current_user.simulation.id), method: :post, class: 'btn btn-primary' %>
 <%= link_to '資産入力に戻る', user_assets_path, class: 'btn btn-secondary', data: { turbo: true } %>
 
 <div id="life_events">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,11 @@ Rails.application.routes.draw do
       post :simulate
     end
   end
-  resources :life_events, only: [:index, :create, :destroy]
+  resources :life_events do
+    collection do
+      post :update_life_event_data
+    end
+  end
   resources :scenarios, only: [:index]
 
   # トップページ


### PR DESCRIPTION
◼︎simulationテーブルのlife_event_dataを更新するロジック追加

※一括払いの支払いスパンのみ追加しており、毎年払いやその他の支払い等の実装有無、仕様について検討する必要あり。
※現実と理想を区別しないロジックとなっており、新カラムをsimulationテーブルに用意し区別して保存をするか、1つのjasonbデータ内に、現実or理想を判断する値を追加するかを検討する必要あり。
※ボタン仕様について検討する必要あり、buttonが今のところ確実。