### PR TITLE
feat: edit expense rogic

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -6,18 +6,30 @@ class ExpensesController < ApplicationController
     @expense = Expense.new
   end
 
-  def create
-    @expense = current_user.expenses.build(convert_repayment_date(expense_params))
+  def create_or_update
+    # ユーザーの最新のexpenseを取得
+    @expense = current_user.expenses.last || current_user.expenses.build
+
+    # 新しいパラメータを反映
+    @expense.assign_attributes(convert_repayment_date(expense_params))
     @expense.simulation = current_user.simulation
 
     if @expense.save
-      @expense.update_simulation_expense_data(current_user)
-      @last_expense = current_user.expenses.last
       respond_to_format
-      redirect_to user_assets_path
+      @last_expense = current_user.expenses.last
+
     else
       @last_expense = @expense
       render_create_error
+    end
+  end
+
+  def update_simulation_data
+    expense = current_user.expenses.find(params[:id])
+    if expense.update_simulation_data(current_user)
+      redirect_to expenses_path, notice: 'シミュレーションデータが更新されました。'
+    else
+      redirect_to expenses_path, alert: 'シミュレーションデータの更新に失敗しました。'
     end
   end
 

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -11,12 +11,19 @@ class Expense < ApplicationRecord
   validates :monthly_premiums, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :other_expenses, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
-  def update_simulation_expense_data(current_user)
+  def update_simulation_data(current_user)
     current_year = Date.today.year
-    retirement_date = current_user.incomes.order(created_at: :desc).first.retirement_date
-    expense_data = calculate_expenses(current_year, retirement_date)
-
+    user_age = current_year - current_user.date_of_birth.year
+  
+    if user_age >= 70
+      errors.add(:base, "既に70歳以上のため計算を実行できません")
+      return
+    end
+  
+    seventy_year_old_year = current_year + (70 - user_age)
+    expense_data = calculate_expenses(current_year, seventy_year_old_year)
     simulation_record = current_user.simulation
+  
     if simulation_record
       simulation_record.update(expense_data: expense_data)
     else
@@ -24,20 +31,20 @@ class Expense < ApplicationRecord
     end
   end
 
-  def calculate_expenses(current_year, retirement_date)
+  def calculate_expenses(current_year, seventy_year_old_year)
     total_expense_per_month = housing_expense + living_expenses + monthly_premiums + other_expenses
     expense_data = []
-
+  
     if repayment_date.nil?
       # 住宅ローンがない場合
-      (current_year..retirement_date.year).each do |year|
+      (current_year..seventy_year_old_year).each do |year|
         yearly_expense = total_expense_per_month * 12 * -1
         expense_data << { date: year, amount: yearly_expense }
       end
     else
       # 住宅ローンがある場合
       repayment_year = repayment_date.year.to_i
-      (current_year..retirement_date.year).each do |year|
+      (current_year..seventy_year_old_year).each do |year|
         if year <= repayment_year
           yearly_expense = (housing_expense + living_expenses + monthly_premiums + other_expenses) * 12 * -1
         else

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Expenses</h1>
 
-<%= form_with model: @expense, url: expenses_path, local: true, id: "income-form" do |f| %>
+<%= form_with model: @expense, url: create_or_update_expenses_path, method: :post, local: true, id: "expense-form" do |f| %>
   <div class="form-group">
     <%= f.label :housing_expense, '住居費（月額）※家賃またはローン', class: 'form-label' %>
     <%= f.number_field :housing_expense, class: 'form-control', required: true %>
@@ -22,7 +22,7 @@
     <%= f.number_field :other_expenses, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <%= f.submit '保存して次へ', class: 'btn btn-primary' %>
+    <%= f.submit '追加', class: 'btn btn-primary' %>
   </div>
 <% end %>
 <%= link_to '収入入力に戻る', incomes_path, class: 'btn btn-secondary', data: { turbo: true } %>
@@ -34,3 +34,7 @@
     <p>No expense data available.</p>
   <% end %>
 </div>
+
+<% if @last_expense %>
+  <%= button_to '保存して次へ', update_simulation_data_expense_path(@last_expense), method: :post, class: 'btn btn-primary' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,14 @@ Rails.application.routes.draw do
       post :update_simulation_data
     end
   end
-  resources :expenses, only: [:index, :create]
+  resources :expenses, only: [:index] do
+    collection do
+      post :create_or_update
+    end
+    member do
+      post :update_simulation_data
+    end
+  end
   resources :user_assets do
     collection do
       post :simulate


### PR DESCRIPTION
◼︎expense rogicの修正
　・createで追加処理をするのではなく、すでにexpenseデータがある場合はupdateを適用しディスク増加を防止
　・simulationテーブルに保存をするexpense_dataを更新する処理は、expenseの保存直後ではなく、新しく設置したボタンを押下すると発動するように修正。