### PR TITLE
refactor: rename & add column in simulations table

### DIFF
--- a/app/models/life_event.rb
+++ b/app/models/life_event.rb
@@ -13,7 +13,7 @@ class LifeEvent < ApplicationRecord
   validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :payment_span, presence: true
 
-  # ビジネスロジック：life_event_dataを更新
+  # ビジネスロジック：real_life_event_dataを更新
   def self.update_simulation_data(simulation_id)
     # 指定されたsimulation_idに関連するlife_eventsを取得
     life_events = LifeEvent.where(simulation_id: simulation_id)
@@ -24,11 +24,11 @@ class LifeEvent < ApplicationRecord
     end
 
     # ハッシュ配列に変換
-    life_event_data = year_amounts.map do |year, amount|
+    real_life_event_data = year_amounts.map do |year, amount|
       { date: year, amount: amount } # dateを年のみの形式にする
     end
 
     # simulationテーブルを直接更新
-    Simulation.find(simulation_id).update(life_event_data: life_event_data)
+    Simulation.find(simulation_id).update(real_life_event_data: real_life_event_data)
   end
 end

--- a/db/migrate/20241206153712_rename_life_event_data_and_add_ideal_life_event_data_to_simulations.rb
+++ b/db/migrate/20241206153712_rename_life_event_data_and_add_ideal_life_event_data_to_simulations.rb
@@ -1,0 +1,6 @@
+class RenameLifeEventDataAndAddIdealLifeEventDataToSimulations < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :simulations, :life_event_data, :real_life_event_data
+    add_column :simulations, :ideal_life_event_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_06_084139) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_06_153712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -102,7 +102,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_06_084139) do
     t.datetime "updated_at", null: false
     t.jsonb "expense_data"
     t.jsonb "user_asset_data"
-    t.jsonb "life_event_data"
+    t.jsonb "real_life_event_data"
+    t.jsonb "ideal_life_event_data"
     t.index ["user_id"], name: "index_simulations_on_user_id"
   end
 


### PR DESCRIPTION
◼︎simulationsテーブルの変更
　・life_event_dataをreal_life_event_dataへ名前変更
　・ideal_life_event_dataカラムを追加
◼︎上記に伴う、life_eventsコントローラーの記述修正