### PR TITLE
feat: edit create logic for scenarios_table & scenario view

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -2,6 +2,14 @@ class ScenariosController < ApplicationController
   def index
     @simulation = Simulation.find_by(user_id: current_user.id)
     @scenario = Scenario.find_by(user_id: current_user.id)
+    #現実的シナリオ
     @chart_data = @scenario.balance_chart_data
+    #@total_income = @scenario.total_income
+    #@total_expense = @scenario.total_expense
+    #@total_balance = @total_expense + @total_income
+
+    @real_total_income = @scenario.total_income || 0
+    @real_total_expense = @scenario.total_expense || 0
+    @real_total_balance = @real_total_income + @real_total_expense
   end
 end

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -7,16 +7,19 @@ class SimulationsController < ApplicationController
     total_income = simulation.total_income
     total_expense = simulation.total_expense
 
-    # シナリオテーブルの更新
-    scenario = simulation.scenarios.update!(
-      user_id: simulation.user_id,
-      scenario_type: '現実', # 注意点2
-      balance_scenario: merged_data, # 注意点1・3
-      total_income: total_income, # ②
-      total_expense: total_expense # ③
+    # `scenario_type: '現実'` のデータを取得
+    scenario = simulation.scenarios.find_by!(scenario_type: '現実')
+
+    # 該当するシナリオを更新
+    scenario.update!(
+      balance_scenario: merged_data,
+      total_income: total_income,
+      total_expense: total_expense
     )
 
     redirect_to scenarios_path, notice: 'シナリオを更新しました。'
+  rescue ActiveRecord::RecordNotFound
+    redirect_to scenarios_path, alert: "現実のシナリオが見つかりませんでした。"
   rescue => e
     redirect_to scenarios_path, alert: "シナリオ更新中にエラーが発生しました: #{e.message}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,8 +26,13 @@ class User < ApplicationRecord
   def create_simulation_and_scenario_models
     # 計算モデルを作成
     Simulation.create(user: self)
-    # 結果モデルを作成
-    Scenario.create(user: self, simulation: simulation)
+
+    # シナリオのタイプを配列に定義
+    scenario_types = ['現実', '理想']
+    # 各シナリオタイプに対してシナリオを作成
+    scenario_types.each do |type|
+      Scenario.create(user: self, simulation: simulation, scenario_type: type)
+    end
   end
 
   def password_present?

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -7,9 +7,11 @@
 </div>
 
 <%= button_to 'シナリオを作成する', update_scenario_simulation_path(@simulation), method: :post, class: 'btn btn-primary' %>
-<%= line_chart @chart_data, xtitle: "年", ytitle: "金額", height: "500px", width: "800px" %>
 
-<h1>収支バランスシナリオ</h1>
+<h4>現実的収支シナリオ</h4>
+<p>トータル収入：<%= @real_total_income %>万円</p>
+<p>トータル支出：<%= @real_total_expense %>万円</p>
+<p>トータル収支：<%= @real_total_balance %>万円</p>
 <%= line_chart @chart_data, height: "400px", library: { title: { text: "収支バランス", fontSize: 20 } } %>
 
 <div class="d-flex justify-content-center">


### PR DESCRIPTION
◼︎アカウント作成時にscenarioディスクを「現実」「理想」に分けて作成する仕様に変更
◼︎scenarioビューの表示の修正