### PR TITLE
feat: edit total_expense logic & ideal_scenario view

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -27,7 +27,9 @@ class ScenariosController < ApplicationController
 
     # 理想的シナリオ
     ideal_scenario = @scenarios.find { |scenario| scenario.scenario_type == '理想' }
-    if ideal_scenario
+    events = LifeEvent.where(user_id: current_user.id)
+
+    if ideal_scenario && events.any? { |event| event.event_type == '理想' }
       @ideal_balance_chart_data = ideal_scenario.balance_chart_data
       @ideal_total_income = ideal_scenario.total_income || 0
       @ideal_total_expense = ideal_scenario.total_expense || 0

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -22,7 +22,14 @@ class SimulationsController < ApplicationController
     # 各種データを計算
     merged_data = simulation.merged_income_expense_event(life_event_data)
     total_income = simulation.total_income
-    total_expense = simulation.total_expense(life_event_data)
+
+    # expense_data, real_life_event_data, ideal_life_event_data を統合して合計支出を算出
+    total_expense = simulation.total_expense(
+      simulation.expense_data,
+      simulation.real_life_event_data,
+      life_event_data
+    )
+
     total_balance = total_income + total_expense
 
     # 該当するシナリオを取得

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -25,9 +25,10 @@ class Simulation < ApplicationRecord
     income_data.sum { |entry| entry["amount"].to_f }
   end
 
-  # 合計支出を計算（life_event_data を受け取る）
-  def total_expense(life_event_data)
-    merge_data(expense_data, life_event_data).sum { |entry| entry["amount"].to_f }
+  # 合計支出を計算（複数のデータセットを受け取る）
+  def total_expense(*datasets)
+    # データセットを統合して合計金額を算出
+    merge_data(*datasets).sum { |entry| entry["amount"].to_f }
   end
 
   # expensesテーブルの指定列を合計

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -11,21 +11,21 @@
       <h4>現実的シナリオ</h4>
       <div class="row mb-3">
         <div class="col text-center">
-          <div class="card border-success mb-2">
+          <div class="card border-danger mb-2">
             <div class="card-body">
               <p class="card-text">トータル収入：<%= @real_total_income %>万円</p>
             </div>
           </div>
         </div>
         <div class="col text-center">
-          <div class="card border-danger mb-2">
+          <div class="card border-info mb-2">
             <div class="card-body">
               <p class="card-text">トータル支出：<%= @real_total_expense %>万円</p>
             </div>
           </div>
         </div>
         <div class="col text-center">
-          <div class="card border-info mb-2">
+          <div class="card border-success mb-2">
             <div class="card-body">
               <p class="card-text">トータル収支：<%= @real_total_balance %>万円</p>
             </div>
@@ -46,32 +46,31 @@
       <% end %>
       <%= area_chart @real_balance_chart_data, height: "300px", download: {filename: "現実的シナリオ"}, dataset: {borderWidth: 1} %> 
     </div>
-    
   </div>
-  
-
 
   <div class="card mb-4">
     <div class="card-body">
       <h4>理想的シナリオ</h4>
-      <% if @ideal_balance_chart_data != @real_balance_chart_data %>
+      <% if @ideal_balance_chart_data.empty? %>
+        <p>理想ライフイベントの登録が無いため、理想的シナリオデータがありません。</p>
+      <% else %>
         <div class="row mb-3">
           <div class="col text-center">
-            <div class="card border-success mb-2">
+            <div class="card border-danger mb-2">
               <div class="card-body">
                 <p class="card-text">トータル収入：<%= @ideal_total_income %>万円</p>
               </div>
             </div>
           </div>
           <div class="col text-center">
-            <div class="card border-danger mb-2">
+            <div class="card border-info mb-2">
               <div class="card-body">
                 <p class="card-text">トータル支出：<%=  @ideal_total_expense %>万円</p>
               </div>
             </div>
           </div>
           <div class="col text-center">
-            <div class="card border-info mb-2">
+            <div class="card border-success mb-2">
               <div class="card-body">
                 <p class="card-text">トータル収支：<%=  @ideal_total_balance %>万円</p>
               </div>
@@ -91,8 +90,6 @@
           <p>現在から年額<%=  @ideal_shortage %>万円が不足しています。</p>
         <% end %>
         <%= area_chart  @ideal_balance_chart_data, height: "300px", download: {filename: "理想的シナリオ"}, dataset: {borderWidth: 1} %> 
-      <% else %>
-        <p>理想ライフイベントの登録が無いため、理想的シナリオデータがありません。</p>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
◼︎life_event入力で理想イベントを追加していない場合、ideal_scenario表示をしないように設定。
◼︎ideal_scenarioの計算ロジックを実行する際、total_expenseがreal_life_event_dataを含んでいなかったため、含めて計算できるように修正。