### PR TITLE
feat: add asset_lifespan model & migration

### DIFF
--- a/app/models/asset_lifespan.rb
+++ b/app/models/asset_lifespan.rb
@@ -1,0 +1,7 @@
+class AssetLifespan < ApplicationRecord
+  belongs_to :user
+  belongs_to :simulation
+
+  validates :yearly_lifespans, presence: true
+  validates :summary, presence: true
+end

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -5,6 +5,7 @@ class Simulation < ApplicationRecord
   has_many :user_assets
   has_many :life_events
   has_many :scenarios
+  has_many :asset_lifespans
 
   validates :user_id, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :memos, dependent: :destroy
   has_one :simulation, dependent: :destroy
   has_many :scenarios, dependent: :destroy
+  has_many :asset_lifespans, dependent: :destroy
   
   validates :email, presence: true, uniqueness: true, 
             format: { with: /\A[^@\s]+@[^@\s]+\z/, message: "は有効なメールアドレスである必要があります" }

--- a/db/migrate/20241209181342_create_asset_lifespans.rb
+++ b/db/migrate/20241209181342_create_asset_lifespans.rb
@@ -1,0 +1,11 @@
+class CreateAssetLifespans < ActiveRecord::Migration[7.2]
+  def change
+    create_table :asset_lifespans do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :simulation, null: false, foreign_key: true
+      t.jsonb :yearly_lifespans, null: false, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_06_162542) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_09_181342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "asset_lifespans", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "simulation_id", null: false
+    t.jsonb "yearly_lifespans", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["simulation_id"], name: "index_asset_lifespans_on_simulation_id"
+    t.index ["user_id"], name: "index_asset_lifespans_on_user_id"
+  end
 
   create_table "assets", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -137,6 +147,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_06_162542) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "asset_lifespans", "simulations"
+  add_foreign_key "asset_lifespans", "users"
   add_foreign_key "incomes", "simulations"
   add_foreign_key "incomes", "users"
   add_foreign_key "memos", "users"

--- a/test/fixtures/asset_lifespans.yml
+++ b/test/fixtures/asset_lifespans.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/asset_lifespan_test.rb
+++ b/test/models/asset_lifespan_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AssetLifespanTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
◼︎asset_lifespanモデル、テーブルの作成
◼︎マイグレーションの実行
◼︎上記に伴うuser, simulationモデルのリレーション変更