### PR TITLE
feat: edit asset_lifespan lojic & fix view error

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -12,9 +12,10 @@ class ScenariosController < ApplicationController
     total_assets = @simulation.user_assets.sum(:amount)
     if total_assets <= 0 || monthly_expenses <= 0
       @asset_lifespan = nil
+      @asset_lifespan_updated_at = nil # 資産寿命がない場合もnilを設定
     else
       @asset_lifespan = @simulation.asset_lifespans.last # 最新の資産寿命データを取得
-      @asset_lifespan_updated_at = @asset_lifespan.updated_at
+      @asset_lifespan_updated_at = @asset_lifespan&.updated_at # nilの場合はnilが代入される
     end
 
     # 資産シナリオ

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -73,21 +73,31 @@ class SimulationsController < ApplicationController
     )
   end
 
-  # 年ごとの資産寿命データを計算するヘルパーメソッド
   def calculate_yearly_lifespan(total_assets, monthly_expenses)
     yearly_data = {}
     remaining_assets = total_assets
-    year = Date.today.year
-
-    while remaining_assets > 0
-      yearly_data[year] = remaining_assets
-      remaining_assets -= (monthly_expenses * 12)
-      year += 1
+    current_date = Date.today
+    current_year = current_date.year
+    current_month = current_date.month
+  
+    # 最初の年の残り月分を計算
+    remaining_months = 12 - current_month + 1 # 現在月を含める
+    if remaining_months > 0
+      yearly_data[current_year] = remaining_assets
+      yearly_expense_for_remaining_months = monthly_expenses * remaining_months
+      remaining_assets -= yearly_expense_for_remaining_months
     end
-
-    # 次の年の資産をそのまま格納する
-    yearly_data[year] = remaining_assets
-
+  
+    yearly_expense_for_full_year = monthly_expenses * 12
+    # 翌年以降、12ヶ月単位で計算
+    next_year = current_year + 1
+    while remaining_assets > -yearly_expense_for_full_year
+      yearly_data[next_year] = remaining_assets
+      
+      remaining_assets -= yearly_expense_for_full_year
+      next_year += 1
+    end
+  
     yearly_data
   end
 end


### PR DESCRIPTION
◼︎asset_lifespanの計算を始めてマイナスとなる年まで算出する仕様に変更。
◼︎データがない場合に@asset_lifespan_updated_atの表示ができないエラーを解消。