### PR TITLE
fix: add dependent destroy to associations in Simulation

### DIFF
--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -1,9 +1,9 @@
 class Simulation < ApplicationRecord
   belongs_to :user
-  has_many :incomes
-  has_many :expenses
-  has_many :user_assets
-  has_many :life_events
+  has_many :incomes, dependent: :destroy
+  has_many :expenses, dependent: :destroy
+  has_many :user_assets, dependent: :destroy
+  has_many :life_events, dependent: :destroy
   has_many :scenarios, dependent: :destroy
   has_many :asset_lifespans, dependent: :destroy
 


### PR DESCRIPTION
◼︎Simulationモデルに各入力モデルのdependent::destroyを追記