### PR TITLE
refactor: edit sns_credential & after_sign_in logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  protected
+
+  # サインイン後とサインアップ後のリダイレクト先を共通化
+  def after_sign_in_path_for(resource)
+    dashboard_path
+  end
+
+  def after_sign_up_path_for(resource)
+    after_sign_in_path_for(resource) # サインイン後と同じパスを利用
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -28,36 +28,32 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   #   super(scope)
   # end
 
+  # Google用のメソッド
   def google_oauth2
+    callback_for(:google)
+  end
+
+  private
+
+  def callback_for(provider)
     auth = request.env["omniauth.auth"]
 
     @user = User.find_or_create_for_oauth(auth)
 
     if @user.persisted?
-      sign_in_and_redirect @user, event: :authentication
-    else
-      redirect_to new_user_registration_url, alert: "SNSログインに失敗しました。"
-    end
-  end
 
-  def callback_for(provider)
-    @omniauth = request.env["omniauth.auth"]
-    info = User.find_oauth(@omniauth)
-    @user = info[:user]
-    @sns = info[:sns]
-    if @user.persisted? # 保存完了しているかを確認する
-      @user.skip_confirmation! if @user.provider.present?  # SNSログイン時はメールアドレス確認をスキップ
+      @user.skip_confirmation! if auth.provider.present?  # SNSログイン時はメールアドレス確認をスキップ
+
+      # サインインしてリダイレクト
       sign_in @user, event: :authentication
-      redirect_to dashboard_path
-      # is_navigational_formatはフラッシュメッセージ表示の必要があるかどうかを確認
-      # capitalizeは文字列の先頭を大文字に、それ以外は小文字に変更して返すメソッド
-      set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
+      redirect_to dashboard_path, notice: "#{provider.to_s.capitalize}でログインしました。"
     else
-      render template: "devise/registrations/new"
+      # 失敗時のリダイレクト先を統一
+      redirect_to new_user_registration_url, alert: "#{provider.to_s.capitalize}ログインに失敗しました。"
     end
   end
 
   def failure
-    redirect_to root_path and return
+    redirect_to root_path
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -19,10 +19,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :date_of_birth])
   end
 
-  def after_sign_up_path_for(resource)
-    dashboard_path
-  end
-
   # GET /resource/sign_up
   # def new
   #   super
@@ -67,11 +63,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
   # end
 
   # The path used after sign up for inactive accounts.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
-
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
-
-  protected
-
-  def after_sign_in_path_for(resource)
-    dashboard_path # dashboardのパスを指定
-  end
 
   # GET /resource/sign_in
   # def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,12 +14,16 @@ class User < ApplicationRecord
   has_many :asset_lifespans, dependent: :destroy
   has_many :sns_credentials, dependent: :destroy
   
+  validates :name, presence: { message: "を入力して下さい" }
   validates :email, presence: true, uniqueness: true, 
             format: { with: /\A[^@\s]+@[^@\s]+\z/, message: "は有効なメールアドレスである必要があります" }
-  # SNSログインでない場合のみ有効とし、password_confirmationはDeviseでのバリデーションでカバー（validatableモジュール確認）
+  validates :date_of_birth,
+            format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'はYYYY-MM-DD形式で入力してください' },
+            if: :date_of_birth_required?
+  # SNSログインでない場合のみ有効、password_confirmationはDeviseのバリデーションでカバー（validatableモジュール確認）
   validates :password, presence: true, length: { in: 8..128 },
-            format: { with: /(?=.*[a-z])(?=.*\d)/, message: "は小文字と数字を含める必要があります" }, if: :password_required?
-  validates :date_of_birth, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'はYYYY-MM-DD形式で入力してください' }, if: :date_of_birth_required?
+            format: { with: /(?=.*[a-z])(?=.*\d)/, message: "は小文字と数字を含める必要があります" },
+            if: :password_required?
 
   after_create :create_simulation_and_scenario_models  # ユーザー作成後に計算モデル＆結果モデルを作成
 
@@ -29,55 +33,6 @@ class User < ApplicationRecord
     age = today.year - date_of_birth.year
     age -= 1 if today < date_of_birth + age.years  # 誕生日がまだ来ていない場合は1歳引く
     age
-  end
-
-  class << self
-    def without_sns_data(auth)
-      user = User.find_by(email: auth.info.email)
-
-      if user.nil?
-        user = User.create(
-          name: auth.info.name,
-          email: auth.info.email,
-          date_of_birth: nil,
-          password: Devise.friendly_token(10) + "a1",
-          confirmed_at: Time.current
-        )
-      end
-
-      sns = SnsCredential.create(uid: auth.uid, provider: auth.provider, user_id: user.id)
-      { user:, sns: }
-    end
-
-    def with_sns_data(auth, snscredential)
-      user = User.where(id: snscredential.user_id).first
-
-      if user.blank?
-        user = User.create(
-          name: auth.info.name,
-          email: auth.info.email,
-          date_of_birth: nil,
-          password: Devise.friendly_token(10) + "a1",
-          confirmed_at: Time.current # 必要であれば自動的に確認済みにする
-        )
-      end
-
-      { user: }
-    end
-
-    def find_oauth(auth)
-      uid = auth.uid
-      provider = auth.provider
-      sns = SnsCredential.find_by(uid:, provider:)
-      
-      if sns.present?
-        user = sns.user
-      else
-        user = without_sns_data(auth)[:user]
-      end
-
-      { user:, sns: }
-    end
   end
 
   # SNSログイン用のユーザーを検索または作成
@@ -90,18 +45,15 @@ class User < ApplicationRecord
       user = User.new(
         email: auth.info.email,
         name: auth.info.name,
-        password: Devise.friendly_token[0, 20], # 仮パスワードを設定
-        date_of_birth: nil, # 生年月日は未設定にして保存
+        password: Devise.friendly_token(10) + "a1",
+        date_of_birth: nil,  # 生年月日は未設定とする
         confirmed_at: Time.current
       )
-
       user.save(validate: false)  # バリデーションをスキップして保存
     end
-
     # SNSとユーザーを関連付け
     sns.user = user
     sns.save!
-
     user
   end
 
@@ -116,10 +68,10 @@ class User < ApplicationRecord
   end
 
   def create_simulation_and_scenario_models
-    Simulation.create(user: self)  # 計算モデル作成
+    Simulation.create(user: self)  # simulationsテーブル作成
 
     scenario_types = ['現実', '理想']  # シナリオのタイプを配列に定義
-    # 各シナリオタイプに対してシナリオを作成
+    # 各シナリオタイプに対応するscenariosテーブル作成
     scenario_types.each do |type|
       Scenario.create(user: self, simulation: simulation, scenario_type: type)
     end


### PR DESCRIPTION
◼︎SNSログインロジックの冗長箇所の修正
◼︎def after_sign_in_path_for とdef after_sign_up_path_for をapplication_controllerに集約