### PR TITLE
feat: edit layout for users with SNS credentials

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,7 +9,11 @@
       <%= form_for @user, data: { turbo: true }, html: { class: 'needs-validation', novalidate: true } do |f| %>
         <div class="mb-3">
           <%= f.label :name, 'ユーザー名', class: 'form-label' %>
-          <%= f.text_field :name, autofocus: true, class: 'form-control' %>
+          <% if @user.sns_credentials.exists? %>
+            <%= f.text_field :name, autofocus: true, class: 'form-control', disabled: true %>
+          <% else %>
+            <%= f.text_field :name, autofocus: true, class: 'form-control' %>
+          <% end %>
         </div>
 
         <div class="mb-3">
@@ -20,24 +24,33 @@
 
         <div class="mb-3">
           <%= f.label :email, 'メールアドレス', class: 'form-label' %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
-        </div>
-
-        <div class="mb-3">
-          <%= f.label :password, 'パスワード', class: 'form-label' %>
-          <% if @minimum_password_length %>
-            <em><%= @minimum_password_length %> characters minimum)</em>
+          <% if @user.sns_credentials.exists? %>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', disabled: true %>
+          <% else %>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
           <% end %>
-          <em>※ 変更する場合のみ入力</em><br />
-          <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
         </div>
 
-        <div class="mb-3">
-          <%= f.label :password_confirmation, 'パスワード(確認用)', class: 'form-label' %>
-          <em>※ 変更する場合のみ入力</em><br />
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
-        </div>
+        <% if @user.sns_credentials.exists? %>
+          <div class="mb-3">
+            <p class="text-center">googleアカウントでのログインを使用しています</p>
+          </div>
+        <% else %>
+          <div class="mb-3">
+            <%= f.label :password, 'パスワード', class: 'form-label' %>
+            <% if @minimum_password_length %>
+              <em><%= @minimum_password_length %> characters minimum)</em>
+            <% end %>
+            <em>※ 変更する場合のみ入力</em><br />
+            <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
+          </div>
 
+          <div class="mb-3">
+            <%= f.label :password_confirmation, 'パスワード(確認用)', class: 'form-label' %>
+            <em>※ 変更する場合のみ入力</em><br />
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
+          </div>
+        <% end %>
         <div class="actions text-center">
           <%= f.submit "保存", class: 'btn btn-outline-primary' %>
           <%= link_to "キャンセル", user_path(@user), class: "btn btn-outline-secondary", data: { turbo: true } %>


### PR DESCRIPTION
◼︎SNSログインを使用するユーザーのためのユーザー情報変更画面の編集
　・名前、メールアドレスを編集不可とする
　・パスワード編集欄を非表示