### PR TITLE
refactor: edit meta tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title><%= content_for(:title) || "Scenapla" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,17 +26,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_23_104453) do
     t.index ["user_id"], name: "index_asset_lifespans_on_user_id"
   end
 
-  create_table "assets", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "simulation_id", null: false
-    t.integer "person_type", default: 0, null: false
-    t.integer "asset_type", default: 0, null: false
-    t.decimal "amount", default: "0.0", null: false
-    t.decimal "yield"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "expenses", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "simulation_id", null: false


### PR DESCRIPTION
◼︎デベロッパー検証ツールに表示された下記の修正。
 　<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">

　現状は、iOS専用の古いメタタグであり、変更するよう推奨されているため、下記の新しいものに変更。
　<meta name="mobile-web-app-capable" content="yes">