### PR TITLE
feat: update date_of_birth for user(SNS:google)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,11 @@ class ApplicationController < ActionController::Base
 
   # サインイン後とサインアップ後のリダイレクト先を共通化
   def after_sign_in_path_for(resource)
-    dashboard_path
+    if resource.date_of_birth.blank?
+      edit_date_of_birth_path
+    else
+      dashboard_path
+    end
   end
 
   def after_sign_up_path_for(resource)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -46,7 +46,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
       sign_in @user, event: :authentication
       if @user.date_of_birth.nil?
-        redirect_to edit_user_registration_path, notice: "#{provider.to_s.capitalize}でログインしました。"
+        redirect_to edit_date_of_birth_path, notice: "#{provider.to_s.capitalize}でログインしました。"
       else
         redirect_to dashboard_path, notice: "#{provider.to_s.capitalize}でログインしました。"
       end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,7 +8,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     super do |resource|
       if resource.persisted? && resource.sns_credentials.empty?
-        sign_out resource unless resource.confirmed?
+        sign_out resource unless resource.confirmed?  # SNSを使用しないユーザー用
       end
     end
   end
@@ -18,6 +18,24 @@ class Users::RegistrationsController < Devise::RegistrationsController
       redirect_to user_path(resource), notice: 'アカウント情報が更新されました'
     else
       render :edit
+    end
+  end
+
+  # 生年月日を登録するページ表示
+  def edit_date_of_birth
+    @resource = current_user
+    unless current_user
+      redirect_to new_user_session_path, alert: 'ログインしてください。'
+    end
+  end
+
+  # 生年月日を更新
+  def update_date_of_birth
+    if current_user.update(date_of_birth_params)
+      redirect_to dashboard_path, notice: '生年月日を登録しました。'
+    else
+      flash.now[:alert] = '生年月日の登録に失敗しました。'
+      render :edit_date_of_birth, status: :unprocessable_entity
     end
   end
 
@@ -57,4 +75,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  private
+
+  def date_of_birth_params
+    params.require(:user).permit(:date_of_birth)
+  end
 end

--- a/app/views/devise/registrations/edit_date_of_birth.html.erb
+++ b/app/views/devise/registrations/edit_date_of_birth.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title do %>date_of_birth<% end %>
+  
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-10 col-md-4 border border-dark p-3 rounded">
+      <h5 class="card-title mb-4 text-center">始めるには生年月日を登録して下さい。</h5>
+      <%= form_with model: current_user, url: update_date_of_birth_path, method: :patch, local: true do |f| %>
+        <%= render "devise/shared/error_messages", resource: @resource %>
+        <div class="form-group">
+          <%= f.label :date_of_birth, '生年月日' %>
+          <%= f.date_field :date_of_birth, class: 'form-control', required: true %>
+        </div>
+
+        <div class="form-group text-center">
+          <%= f.submit '登録', class: 'btn btn-outline-primary' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,12 @@ Rails.application.routes.draw do
     sessions: 'users/sessions',
     omniauth_callbacks: 'users/omniauth_callbacks',
   }
-  resources :users, only: [:show, :edit, :update]
+  devise_scope :user do
+    # SNSログインユーザーの生年月日登録
+    get 'users/date_of_birth/edit', to: 'users/registrations#edit_date_of_birth', as: 'edit_date_of_birth'
+    patch 'users/date_of_birth', to: 'users/registrations#update_date_of_birth', as: 'update_date_of_birth'
+  end
+  resources :users, only: [:show]
   resources :incomes do
     collection do
       post :update_simulation_data


### PR DESCRIPTION
◼︎googleアカウントを使用するユーザーの、ログイン後の生年月日登録機能を追加
　1. application_controller.rb、omniauth_callbacks_controller.rb
　・サインアップ後の生年月日がnilの場合の条件分岐を追加。
　・リダイレクト先の編集。

　2. app/controllers/users/registrations_controller.rb
　・生年月日の単体登録処理を追加

　3. edit_date_of_birth.html.erb
　・ビューの追加

　4. 生年月日単体登録用のルーティングの追加
　　
