### PR TITLE
style: update life_event layout & style

### DIFF
--- a/app/controllers/life_events_controller.rb
+++ b/app/controllers/life_events_controller.rb
@@ -1,8 +1,13 @@
 class LifeEventsController < ApplicationController
   def index
-    # ユーザーのライフイベントを取得して年代ごとにグループ化
+    # 表示する年代を計算
+    @age_groups_to_display = ((current_user.age / 10) * 10..70).step(10).to_a
+  
+    # ライフイベントを年代毎にグループ化
     life_events = LifeEvent.where(user_id: current_user.id).order(event_date: :asc)
     @grouped_life_events = life_events.group_by { |event| calculate_age_group(event.event_date.year, current_user.date_of_birth.year) }
+    
+    # メモを年代毎にグループ化
     @memos = Memo.where(user_id: current_user.id).group_by(&:age_group)
   end
 

--- a/app/views/life_events/_life_event.html.erb
+++ b/app/views/life_events/_life_event.html.erb
@@ -7,7 +7,11 @@
       data-bs-target="#collapse-<%= accordion_id %>-<%= index %>"
       aria-expanded="false"
       aria-controls="collapse-<%= accordion_id %>-<%= index %>">
-      <%= life_event.event_date.year %>年（<%= life_event.event_type %>）<%= life_event.title %>
+        <span class="badge rounded-pill <%= life_event.event_type == '理想' ? 'text-success' : 'text-primary' %>">
+          <%= life_event.event_type %>
+        </span>
+        <span class="me-2"></span>
+        <%= life_event.event_date.year %>年 <%= life_event.title %>
     </button>
   </h2>
   <div
@@ -18,7 +22,6 @@
 
     <div class="accordion-body">
       <ul class="list-unstyled">
-        <li><strong>イベントタイプ:</strong> <%= life_event.event_type %></li>
         <li><strong>年額:</strong> <%= life_event.amount %>万円</li>
         <li><strong>支払期間:</strong> <%= life_event.payment_span %>年間</li>
       </ul>

--- a/app/views/life_events/index.html.erb
+++ b/app/views/life_events/index.html.erb
@@ -7,48 +7,51 @@
     <p>今後の計画や目標などをメモに整理しましょう。</p>
   </div>
 
-  <% if @grouped_life_events.empty? %>
-    <div class="card mb-4">
+  <% @age_groups_to_display.each do |age_group| %>
+    <div class="card mb-3">
       <div class="card-body">
-        <p>ライフイベントが未登録のため、表示できません。</p>
-      </div>
-    </div>
-  <% else %>
-    <% @grouped_life_events.each do |age_group, events| %>
-      <div class="card mb-4">
-        <div class="card-body">
-          <h3><%= age_group %>代</h3>
-          <div class="row">
-            <div class="col-md-5">
+        <h3><%= age_group %>代</h3>
+        <div class="row">
+          <div class="col-md-5">
+            <% if @grouped_life_events[age_group].blank? %>
+              <p>ライフイベント未登録</p>
+            <% else %>
               <div class="accordion" id="lifeEventsAccordion-<%= age_group %>">
-                <% events.each_with_index do |life_event, index| %>
-                  <%= render 'life_event', life_event: life_event, index: index, accordion_id: "lifeEventsAccordion-#{age_group}", show_delete_button: false %>
+                <% @grouped_life_events[age_group].each_with_index do |life_event, index| %>
+                  <%=
+                    render 'life_event', 
+                    life_event: life_event,
+                    index: index,
+                    accordion_id: "lifeEventsAccordion-#{age_group}",
+                    show_delete_button: false
+                  %>
                 <% end %>
               </div>
-            </div>
-            <div class="col mt-2 mt-md-0">
-              <% first_memo = @memos[age_group]&.first %>
-              <div id="memo-container-<%= age_group %>">
-                <textarea id="memo-content-<%= age_group %>" rows="2" class="form-control" data-age-group="<%= age_group %>" data-id="<%= first_memo&.id %>" <%= first_memo&.content.present? ? 'readonly' : '' %>><%= first_memo&.content.present? ? first_memo.content : '' %></textarea>
-                <button id="memo-button-<%= age_group %>"
-                  class="btn <%= first_memo&.content.present? ? 'btn-secondary' : 'btn-primary' %> btn-sm mt-2"
-                  data-action="<%= first_memo&.content.present? ? 'edit' : 'save' %>">
+            <% end %>
+          </div>
+          <div class="col mt-2 mt-md-0">
+            <% first_memo = @memos[age_group]&.first %>
+            <div id="memo-container-<%= age_group %>">
+              <textarea id="memo-content-<%= age_group %>" rows="2" class="form-control" data-age-group="<%= age_group %>" data-id="<%= first_memo&.id %>" <%= first_memo&.content.present? ? 'readonly' : '' %>><%= first_memo&.content.present? ? first_memo.content : '' %></textarea>
+              <button
+                id="memo-button-<%= age_group %>"
+                class="btn <%= first_memo&.content.present? ? 'btn-outline-secondary' : 'btn-outline-primary' %> btn-sm mt-2"
+                data-action="<%= first_memo&.content.present? ? 'edit' : 'save' %>">
                   <%= first_memo&.content.present? ? '編集' : '保存' %>
-                </button>
-              </div>
+              </button>
             </div>
           </div>
         </div>
       </div>
-    <% end %>
+    </div>
   <% end %>
 
   <div class="d-flex justify-content-center">
     <% if @grouped_life_events.empty? %>
-      <%= link_to '情報入力画面へ', incomes_path, class: 'btn btn-primary me-2', data: { turbo_method: :get } %>
+      <%= link_to '情報入力画面へ', incomes_path, class: 'btn btn-primary me-2', data: { turbo: true } %>
     <% else %>
       <div class="d-flex justify-content-center">
-        <%= link_to 'ライフイベント編集', new_life_event_path, class: 'btn btn-secondary me-2', data: { turbo: true } %>
+        <%= link_to 'ライフイベント編集', new_life_event_path, class: 'btn btn-outline-secondary me-2', data: { turbo: true } %>
         <%= link_to 'ホームに戻る', dashboard_path, class: 'btn btn-primary me-2', data: { turbo: true } %>
       </div>
     <% end %>
@@ -100,7 +103,7 @@
                 newButton.dataset.action = "edit";
                 newButton.textContent = "編集";
                 textarea.setAttribute("readonly", true);
-                newButton.classList.replace("btn-primary", "btn-secondary");
+                newButton.classList.replace("btn-outline-primary", "btn-outline-secondary");
               } else {
                 alert(data.message || "保存に失敗しました。");
               }
@@ -110,7 +113,7 @@
           newButton.dataset.action = "save";
           newButton.textContent = "保存";
           textarea.removeAttribute("readonly");
-          newButton.classList.replace("btn-secondary", "btn-primary");
+          newButton.classList.replace("btn-outline-secondary", "btn-outline-primary");
         }
       });
     });

--- a/app/views/life_events/new.html.erb
+++ b/app/views/life_events/new.html.erb
@@ -60,14 +60,17 @@
       <% end %>
     </div>
 
-
     <div class="col-11 mb-4">
       <div class="row">
         <h5>追加したライフイベントデータ</h5>
         <% if @life_events.any? %>
           <div class="accordion" id="newLifeEventsAccordion">
             <% @life_events.each_with_index do |life_event, index| %>
-              <%= render 'life_event',life_event: life_event, index: index, accordion_id: "newLifeEventsAccordion" , show_delete_button: true %>
+              <%=
+                render 'life_event',
+                life_event: life_event, index: index, accordion_id: "newLifeEventsAccordion",
+                show_delete_button: true
+              %>
             <% end %>
           </div>
         <% else %>
@@ -81,8 +84,10 @@
     <%= link_to '資産に戻る', user_assets_path, class: 'btn btn-outline-secondary me-2', data: { turbo: true } %>
     <% if @life_events.any? %>
       <%=
-        button_to '保存して次へ', update_life_event_data_life_events_path(simulation_id: current_user.simulation.id),
-        method: :post, class: 'btn btn-primary', data: { turbo: true }
+        button_to '保存して次へ',
+        update_life_event_data_life_events_path(simulation_id: current_user.simulation.id),
+        method: :post,
+        class: 'btn btn-primary', data: { turbo: true }
       %>
     <% end %>
   </div>


### PR DESCRIPTION
◼︎ライフプランページ表示変更
　・これまでは、登録されたライフイベントの年代のみのメモを表示していたが、ユーザーが70代になるまで10年毎に全期間表示する仕様に変更。
　・上記に伴い、app/controllers/life_events_controller.rb内indexメソッドの処理変更。
　・理想と現実のイベントタイプが一目でわかるように、各ライフイベントの先頭にバッジを表示。
　・メモ保存/編集ボタンの表示変更
　・アコーディオンのヘッダーに表示されている項目と、アコーディオン内容（開いた後）に表示される内容の重複削除。

◼︎ライフイベント登録ページのhtmlの記述スタイル変更。