### PR TITLE
feat: implement caching for news display

### DIFF
--- a/app/services/g_news_service.rb
+++ b/app/services/g_news_service.rb
@@ -7,28 +7,34 @@ class GNewsService
     @api_key = fetch_api_key
   end
 
-  # ニュースを取得するメインメソッド
+  # ニュースを取得するメインメソッド（キャッシュ対応）
   def fetch_news(topic, options = {})
     language = options[:language] || 'ja'       # 言語（デフォルト: 日本語）
     max = options[:max] || 10                   # 最大取得件数（デフォルト: 10）
     endpoint = options[:endpoint] || '/search'  # エンドポイント（デフォルト: /search）
 
-    response = HTTP.get("#{BASE_URL}#{endpoint}", params: {
-      q: topic,
-      lang: language,
-      max: max,
-      token: @api_key
-    })
+    cache_key = "gnews/#{topic}/#{language}/#{max}"  # キャッシュキーを作成
 
-    handle_response(response)
+    # キャッシュがあれば取得、なければAPIリクエスト
+    result = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      Rails.logger.info("Cache miss for key: #{cache_key}. Fetching data from API.")
+
+      response = HTTP.get("#{BASE_URL}#{endpoint}", params: {
+        q: topic,
+        lang: language,
+        max: max,
+        token: @api_key
+      })
+      handle_response(response)
+    end
+
+    # キャッシュがある場合のログ出力
+    Rails.logger.info("Cache hit for key: #{cache_key}. Returning cached data.") if Rails.cache.exist?(cache_key)
+
+    result
   rescue StandardError => e
     Rails.logger.error "GNews API Error: #{e.message}"
     []
-  end
-
-  # 日本経済ニュース専用の簡易メソッド
-  def fetch_japanese_economy_news
-    fetch_news('日本経済', language: 'ja', max: 10)
   end
 
   private


### PR DESCRIPTION
◼︎ニュース表示機能にキャッシュを実装
　・キャッシュが存在する場合は、キャッシュよりニュースを取得し、存在しない場合はAPIから取得
　・キャッシュの有効期限は24時間
　→APIのリクエスト制限対策