### PR TITLE
fix: change og:image URL for sharing compatibility

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <meta property="og:description" content="このアプリは、経済とライフイベントの計画をサポートするツールです。">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://scenapla.com">  <!-- トップページURL -->
-    <meta property="og:image" content="<%= asset_path('default-ogp-image.png') %>">  <!-- OGP用画像 -->
+    <meta property="og:image" content="<%= asset_url('default-ogp-image.png') %>">  <!-- OGP用画像 -->
     <meta property="og:site_name" content="Scenapla">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@scenapla">


### PR DESCRIPTION
◼︎og:imageの記述変更
　・facebookのシェアデバッガーで「指定されたog:image URL「/assets/default-ogp-image-b771....c.png」は有効なURLではありません。」と表示される問題に対して、asset_path('default-ogp-image.png')ではなく、asset_url('default-ogp-image.png')を使用する