### PR TITLE
chore: add Dockerfile setup for RuboCop & integrate Makefile for efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN bundle install && \
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
+# Install RuboCop and related tools
+RUN gem install rubocop rubocop-rails rubocop-performance
+
 # Copy application code
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# 定義: Docker Composeを使った便利コマンド集
+# Docker Compose内のwebコンテナを使ってコマンドを実行する。
+
+# 定義済み変数
+COMPOSE = docker compose
+SERVICE = web
+
+# RuboCop関連タスク
+rubocop:
+	$(COMPOSE) run --rm $(SERVICE) bundle exec rubocop
+
+rubocop-autocorrect:
+	$(COMPOSE) run --rm $(SERVICE) bundle exec rubocop --auto-correct
+
+rubocop-gen-config:
+	$(COMPOSE) run --rm $(SERVICE) bundle exec rubocop --auto-gen-config
+
+# その他便利タスク
+build:
+	$(COMPOSE) build
+
+up:
+	$(COMPOSE) up
+
+down:
+	$(COMPOSE) down
+
+logs:
+	$(COMPOSE) logs -f


### PR DESCRIPTION
◼︎Docker環境内でrubocopを効率的に使用するため、必要な設定やツールをDockerfileに組み込み作業
　・Gemfileのインストール後にgem installを追加し、他の依存関係（rubocop-railsやrubocop-performanceなど）を含めた。

◼︎makefileを導入し作業効率化を図る作業
　・makefileを作成し、基本的なdockerコマンドと、rubocopコマンドを追加