### PR TITLE
fix: incomes request spec

### DIFF
--- a/app/controllers/incomes_controller.rb
+++ b/app/controllers/incomes_controller.rb
@@ -11,10 +11,9 @@ class IncomesController < ApplicationController
     @income.simulation = current_user.simulation
 
     if @income.save
-      render_success(t("notice.income.create.success"))
-      head :created  # 201を返す
+      redirect_to incomes_path, notice: t("notice.income.create.success")
     else
-      render_error(@income.errors.full_messages.join(", "))
+      render_error(@income.errors.full_messages.join(", "), :unprocessable_entity)
     end
   end
 
@@ -23,10 +22,9 @@ class IncomesController < ApplicationController
 
     if @income
       @income.destroy
-      render_success(t("notice.income.destroy.success"))
-      head :no_content  # 204を返す
+      redirect_to incomes_path, alert: t("notice.income.destroy.success")
     else
-      redirect_to incomes_path, alert: t("alert.income.destroy.not_found")
+      render_error(t("alert.income.destroy.not_found"), :not_found)
     end
   end
 
@@ -48,13 +46,8 @@ class IncomesController < ApplicationController
     params.require(:income).permit(:person_type, :income, :retirement_date, :retirement_pay)
   end
 
-  def render_success(message)
-    flash.now[:notice] = message
-    render :index, status: :unprocessable_entity
-  end
-
-  def render_error(message)
-    flash.now[:error] = message
-    render :index, status: :unprocessable_entity
+  def render_error(message, status)
+    flash.now[:alert] = message
+    render :index, status: status
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,13 +5,13 @@ ja:
         success: "収入データを追加しました。"
       destroy: 
         success: "収入データを削除しました。"
-        error: "収入データを削除できませんでした。"
     simulation:
       update:
         success: "シミュレーションデータに保存しました。"
   alert:
     income:
       destroy:
+        error: "収入データを削除できませんでした。"
         not_found: "収入データが見つかりません"
     simulation:
       update:

--- a/spec/requests/incomes_spec.rb
+++ b/spec/requests/incomes_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Incomes", type: :request do
   end
 
   describe "GET /index" do
-    it "HTTPステータ200を返す" do
+    it "ページを表示し200を返す" do
       get incomes_path
-      expect(response).to have_http_status(:success)  # 200
+      expect(response).to have_http_status(:success)
     end
   end
 
@@ -21,10 +21,10 @@ RSpec.describe "Incomes", type: :request do
       { income: attributes_for(:income) }
     end
 
-    it "保存成功の場合は、201を返す" do
+    it "保存成功の場合は、302を返す" do
       valid_params = { income: attributes_for(:income) }
       post incomes_path, params: valid_params
-      expect(response).to have_http_status(:created) # 201
+      expect(response).to have_http_status(:found)
     end
 
     it "保存失敗の場合は、422返す" do
@@ -35,9 +35,9 @@ RSpec.describe "Incomes", type: :request do
   end
 
   describe "DELETE /destroy" do
-    it "削除成功の場合は、422を返す" do
+    it "削除成功の場合は、302を返す" do
       delete income_path(income)
-      expect(response).to have_http_status(:no_content)  # 204
+      expect(response).to have_http_status(:found)
     end
 
     it "削除失敗の場合は、404を返す" do


### PR DESCRIPTION
◼︎incomesコントローラー修正
　・処理成功時はredirect_toで統一。
　・不正な記述削除。

◼︎上記に伴うincomesリクエストスペックの修正