### PR TITLE
feat: add reqest spec & refactor for scenarios

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -2,67 +2,39 @@ class ScenariosController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @simulation = Simulation.find_by(user_id: current_user.id)
-    @scenarios = Scenario.where(user_id: current_user.id) # 複数のシナリオを取得
+    @simulation = current_user.simulation
+    @scenarios = current_user.scenarios
+    @asset_lifespan = current_user.asset_lifespans.last
 
-    @asset_lifespan = @simulation.asset_lifespans.last # 最新の資産寿命データ
+    # 資産寿命シナリオ
+    @lifespan_years = @asset_lifespan&.lifespan_years
+    @lifespan_months = @asset_lifespan&.lifespan_months
+    @lifespan_chart_data = @asset_lifespan&.user_asset_chart_data
 
-    if @asset_lifespan
-      @lifespan_years = @asset_lifespan.lifespan_years
-      @lifespan_months = @asset_lifespan.lifespan_months
-    else
-      @lifespan_years = nil
-      @lifespan_months = nil
-    end
-
-    # 資産寿命データ　各支出を安全に取得(nilを0に変換)
-    monthly_expenses = @simulation.expenses.sum(:housing_expense).to_f +
-    @simulation.expenses.sum(:living_expenses).to_f +
-    @simulation.expenses.sum(:monthly_premiums).to_f +
-    @simulation.expenses.sum(:other_expenses).to_f
-    # 必要なデータがない場合
+    expense_totals = @simulation.expenses.pluck(:housing_expense, :living_expenses, :monthly_premiums, :other_expenses)
+    monthly_expenses = expense_totals.flatten.sum.to_f
     total_assets = @simulation.user_assets.sum(:amount)
+
     if total_assets <= 0 || monthly_expenses <= 0
       @asset_lifespan = nil
-      @asset_lifespan_updated_at = nil # 資産寿命がない場合もnilを設定
+      @asset_lifespan_updated_at = nil
     else
-      @asset_lifespan = @simulation.asset_lifespans.last # 最新の資産寿命データを取得
-      @asset_lifespan_updated_at = @asset_lifespan&.updated_at # nilの場合はnilが代入される
-    end
-
-    # 資産シナリオ
-    user_assets = @simulation.user_assets.where(user_id: current_user.id)
-    if user_assets.any?
-      @asset_data = @simulation.user_asset_data&.map { |entry| [ entry["date"], entry["amount"] ] }&.to_h || {}
-      @user_asset_data_updated_at = @simulation.updated_at
-    else
-      @asset_data = []
+      @asset_lifespan_updated_at = @asset_lifespan&.updated_at
     end
 
     # 現実的シナリオ
-    real_scenario = @scenarios.find { |scenario| scenario.scenario_type == "現実" }
-    if real_scenario
-      @real_updated_at = real_scenario.updated_at
-      @real_balance_chart_data = real_scenario.balance_chart_data
-      @real_total_income = real_scenario.total_income || 0
-      @real_total_expense = real_scenario.total_expense || 0
-      @real_total_balance = real_scenario.total_balance || 0
-      @real_withdrawal = real_scenario.withdrawal || 0
-      @real_shortage = real_scenario.shortage || 0
-    else
-      # 現実的シナリオが見つからなかった場合の処理
-      @real_balance_chart_data = []
-      @real_total_income = 0
-      @real_total_expense = 0
-      @real_total_balance = 0
-      @real_withdrawal = 0
-      @real_shortage = 0
-    end
+    real_scenario = @scenarios.find { |s| s.scenario_type == "現実" }
+    @real_updated_at = real_scenario&.updated_at
+    @real_balance_chart_data = real_scenario&.balance_chart_data || []
+    @real_total_income = real_scenario&.total_income || 0
+    @real_total_expense = real_scenario&.total_expense || 0
+    @real_total_balance = real_scenario&.total_balance || 0
+    @real_withdrawal = real_scenario&.withdrawal || 0
+    @real_shortage = real_scenario&.shortage || 0
 
     # 理想的シナリオ
-    ideal_scenario = @scenarios.find { |scenario| scenario.scenario_type == "理想" }
-    events = LifeEvent.where(user_id: current_user.id)
-
+    ideal_scenario = @scenarios.find { |s| s.scenario_type == "理想" }
+    events = current_user.life_events
     if ideal_scenario && events.any? { |event| event.event_type == "理想" }
       @ideal_updated_at = ideal_scenario.updated_at
       @ideal_balance_chart_data = ideal_scenario.balance_chart_data
@@ -71,8 +43,7 @@ class ScenariosController < ApplicationController
       @ideal_total_balance = ideal_scenario.total_balance || 0
       @ideal_withdrawal = ideal_scenario.withdrawal || 0
       @ideal_shortage = ideal_scenario.shortage || 0
-    else
-      # 理想的シナリオが見つからなかった場合の処理
+    else  # 理想シナリオが見つからない場合
       @ideal_balance_chart_data = []
       @ideal_total_income = 0
       @ideal_total_expense = 0
@@ -80,14 +51,18 @@ class ScenariosController < ApplicationController
       @ideal_withdrawal = 0
       @ideal_shortage = 0
     end
+
+    # 資産シナリオ
+    @asset_data = @simulation.user_asset_chart_data
+    @user_asset_data_updated_at = @simulation.updated_at if @asset_data.present?
   end
 
   def update_scenarios
     success = current_user.scenarios.all?(&:update_scenario_data!)
     if success
-      redirect_to scenarios_path, notice: "シナリオを更新しました。"
+      redirect_to scenarios_path, notice: t("notice.scenario.update.success")
     else
-      redirect_to scenarios_path, alert: "シナリオを更新できませんでした。"
+      redirect_to scenarios_path, alert: t("alert.scenario.update.error")
     end
   end
 end

--- a/app/models/asset_lifespan.rb
+++ b/app/models/asset_lifespan.rb
@@ -14,4 +14,8 @@ class AssetLifespan < ApplicationRecord
       lifespan_months: lifespan_months
     )
   end
+
+  def user_asset_chart_data
+    yearly_lifespans&.map { |year, amount| [year, amount.to_f] }&.to_h || {}
+  end
 end

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -6,10 +6,11 @@ class Scenario < ApplicationRecord
 
   validates :user_id, :simulation_id, presence: true
 
-  # Chartkick用データ形式を返す
+  # Chart用に整形
   def balance_chart_data
-    balance_scenario.map { |entry| [ entry["date"], entry["amount"] ] }.to_h
+    balance_scenario.map { |entry| [entry["date"], entry["amount"]] }&.to_h || {}
   end
+
 
   # シナリオ更新
   def update_scenario_data!

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -154,4 +154,8 @@ class Simulation < ApplicationRecord
     total_months = (total_assets / monthly_expense).floor
     [ total_months / 12, total_months % 12 ]
   end
+
+  def user_asset_chart_data
+    user_asset_data&.map { |entry| [entry["date"], entry["amount"]] }&.to_h || {}
+  end
 end

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -20,7 +20,7 @@
         <% else %>
           <p>資産情報が登録されていません。</p>
         <% end %>
-        <%= column_chart @asset_lifespan.yearly_lifespans.map { |year, amount| [year, amount.to_f] }, xtitle: '年', ytitle: '資産額（万円）' %>
+        <%= column_chart @lifespan_chart_data, xtitle: '年', ytitle: '資産額（万円）' %>
       <% else %>
         <p>資産情報の登録がないため、グラフを表示できません。</p>
       <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,9 @@ ja:
     simulation:
       update:
         success: "シミュレーションデータに保存しました。"
+    scenario:
+      update:
+        success: "シナリオデータを更新しました。"
   alert:
     income:
       destroy:
@@ -34,6 +37,9 @@ ja:
     simulation:
       update:
         error: "シミュレーションデータに保存できませんでした。"
+    scenario:
+      update:
+        error: "シナリオデータを更新できませんでした。"
   errors:
     format: "%{message}" # 属性名を含めない
     messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,18 +38,22 @@ Rails.application.routes.draw do
     end
   end
 
-  # -----------------------------------------------------------
-  resources :life_events do
+  # life_event関連
+  resources :life_events, only: [ :index, :new, :create, :destroy ] do
     collection do
       post :update_simulation_data
     end
   end
-  resources :memos, only: %i[create update]
-  resources :scenarios do
+
+  # scenario関連
+  resources :scenarios, only: [ :index ] do
     collection do
       post :update_scenarios
     end
   end
+
+  # -----------------------------------------------------------
+  resources :memos, only: %i[create update]
 
   # ニュースページ
   resources :news, only: [ :index ]

--- a/spec/models/simulation_spec.rb
+++ b/spec/models/simulation_spec.rb
@@ -295,5 +295,18 @@ RSpec.describe Simulation, type: :model do
         ])
       end
     end
+
+    describe '#user_asset_chart_data' do
+      before do
+        allow(simulation).to receive(:user_asset_data).and_return([
+          { 'date' => '2000', 'amount' => 200 }, { 'date' => '2001', 'amount' => 100 }
+        ])
+      end
+  
+      it 'Chartkick用にフォーマットする' do
+        expected_result = { '2000' => 200, '2001' => 100 }
+        expect(simulation.user_asset_chart_data).to eq(expected_result)
+      end
+    end
   end
 end

--- a/spec/requests/scenarios_spec.rb
+++ b/spec/requests/scenarios_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe "Scenarios", type: :request do
+  let!(:user) { create(:user) }
+  let!(:simulation) { create(:simulation, user: user) }
+  let!(:scenario) { create(:scenario, user: user, simulation: simulation) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /index" do
+    it "ページを表示し200を返す" do
+      get scenarios_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST /update_scenarios" do
+    it "scenarios_pathにリダイレクトし302を返す" do
+      allow_any_instance_of(Scenario).to receive(:update_scenario_data!).and_return(true)
+
+      post update_scenarios_scenarios_path
+      expect(response).to have_http_status(:found)  # 302
+      expect(response).to redirect_to(scenarios_path)
+    end
+
+    it "scenarios_pathにリダイレクトし302を返す" do
+      allow_any_instance_of(Scenario).to receive(:update_scenario_data!).and_return(false)
+
+      post update_scenarios_scenarios_path
+      expect(response).to have_http_status(:found)  # 302
+      expect(response).to redirect_to(scenarios_path)
+    end
+  end
+end


### PR DESCRIPTION
◼︎scenariosのリクエストスペック追加
　・ステータスコードの確認

◼︎scenariosリファクタリング
　・asset_lifespan_dataをchart用にフォーマットする処理をsimulationモデルに委譲。
　・メッセージをja.yml管理に変更
　・不要なルーティングの削除

◼︎上記リファクタリングに関連するテストの修正
