### PR TITLE
feat: request spec for confirmation, omniauth, users controller

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,20 +4,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # You should configure your model like this:
   # devise :omniauthable, omniauth_providers: [:twitter]
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
-
-  # More info at:
-  # https://github.com/heartcombo/devise#omniauth
-
   # GET|POST /resource/auth/twitter
   # def passthru
-  #   super
-  # end
-
-  # GET|POST /users/auth/twitter/callback
-  # def failure
   #   super
   # end
 
@@ -33,6 +21,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     callback_for(:google)
   end
 
+  def failure
+    redirect_to new_user_registration_path, alert: "ログインに失敗しました。"
+  end
+
   private
 
   def callback_for(provider)
@@ -44,17 +36,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in @user, event: :authentication
       redirect_after_auth(provider)
     else
-      redirect_to new_user_registration_url, alert: "#{provider.to_s.capitalize}ログインに失敗しました。"
+      redirect_to new_user_registration_path, alert: "#{provider.to_s.capitalize}ログインに失敗しました。"
     end
   end
 
   def redirect_after_auth(provider)
     path = @user.date_of_birth.nil? ? edit_date_of_birth_path : dashboard_index_path
-    notice = "#{provider.to_s.capitalize}でログインしました。"
-    redirect_to path, notice: notice
-  end
-
-  def failure
-    redirect_to root_path
+    redirect_to path, notice: "#{provider.to_s.capitalize}でログインしました。"
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,7 +10,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     super do |resource|
       if resource.persisted? && resource.sns_credentials.empty?
-        sign_out resource unless resource.confirmed?  # SNSを使用しないユーザー用
+        sign_out resource unless resource.confirmed?  # SNS未使用ユーザー用
       end
     end
   end
@@ -23,8 +23,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  # 生年月日の単体登録ページ
-  def edit_date_of_birth; end
+  def edit_date_of_birth; end  # 生年月日の単体登録ページ
 
   # 生年月日の単体登録処理
   def update_date_of_birth

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
     age
   end
 
-  # SNSログイン（ユーザーを検索or作成）
+  # snsログイン（ユーザーを検索or作成）
   def self.find_or_create_for_oauth(auth)
     sns = SnsCredential.find_or_create_by(uid: auth.uid, provider: auth.provider)
     user = sns.user || User.find_by(email: auth.info.email)
@@ -41,7 +41,7 @@ class User < ApplicationRecord
 
   private
 
-  # SNSユーザー：登録も更新も無効
+  # sns使用ユーザー：登録も更新も無効
   # 一般ユーザー：登録は有効、更新は入力があれば有効、なければ無効
   def password_required?
     if sns_credentials.exists?
@@ -53,7 +53,7 @@ class User < ApplicationRecord
     end
   end
 
-  # SNS使用ユーザー：登録は無効、更新は有効
+  # sns使用ユーザー：登録は無効、更新は有効
   # 一般ユーザー：登録も更新も有効
   def date_of_birth_required?
     return true if sns_credentials.empty?
@@ -65,17 +65,17 @@ class User < ApplicationRecord
     end
   end
 
+  # 空のsimulation, scenario作成
   def create_simulation_and_scenario_models
     Simulation.create(user: self)
 
-    # 各scenario_typeに対応するテーブル作成
     scenario_types = [ "現実", "理想" ]
     scenario_types.each do |type|
       Scenario.create(user: self, simulation: simulation, scenario_type: type)
     end
   end
 
-  # snsを元にuser作成
+  # snsを元にユーザー作成
   def self.create_user_from_auth(auth)
     user = User.new(
       email: auth.info.email,
@@ -84,7 +84,7 @@ class User < ApplicationRecord
       date_of_birth: nil,  # 生年月日は未設定とする
       confirmed_at: Time.current
     )
-    user.save(validate: false)  # バリデーションをスキップして保存
+    user.save(validate: false)  # バリデーションはスキップ
     user
   end
 

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Dashboards", type: :request do
     context "未ログインの場合" do
       it "loginページにリダイレクトし302を返す" do
         get dashboard_index_path
-        expect(response).to have_http_status(:found) # 302リダイレクト
+        expect(response).to have_http_status(:found)  # 302
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+
+RSpec.describe "Users::Confirmations", type: :request do
+  let(:user) { create(:user, confirmed_at: nil) }
+  
+  describe "GET /users/confirmation" do
+    before do
+      user.send_confirmation_instructions  # 新規登録後に確認メール送信処理
+      @token = user.confirmation_token     # 確認トークンを取得
+    end
+
+    it "確認後、正しくリダイレクトする" do
+      get user_confirmation_path(confirmation_token: @token)
+      expect(response).to have_http_status(:found)  # 302
+      expect(response).to redirect_to(dashboard_index_path)
+    end
+
+    it "状態が確認済に正しく変わる" do
+      expect {
+        get user_confirmation_path(confirmation_token: @token)
+        user.reload  # ユーザーを再度読み込み
+      }.to change { user.confirmed? }.from(false).to(true)  # 確認済の状態となる
+    end
+  end
+end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe "Users::OmniauthCallbacks", type: :request do
+  describe "GET /users/auth/google_oauth2/callback" do
+    before do
+      OmniAuth.config.test_mode = true
+    end
+
+    context "認証が成功した場合" do
+      let!(:user) { create(:user) }
+      before do
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+          provider: 'google_oauth2',
+          uid: '123456789',
+          info: { email: 'test@example.com' }
+        )
+      end
+
+      it "認証後、適切にリダイレクトする" do
+        get user_google_oauth2_omniauth_callback_path
+        expect(response).to have_http_status(:found)  # 302
+      end
+    end
+
+    context "認証が失敗した場合" do
+      before do
+        OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
+      end
+
+      it "新規登録ページにリダイレクトする" do
+        get user_google_oauth2_omniauth_callback_path
+        expect(response).to redirect_to(new_user_registration_path)
+        expect(response).to have_http_status(:found)  # 302
+      end
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /users/:id" do
+    it "ページを表示し200を返す" do
+      get user_path(user)
+      expect(response).to have_http_status(:success)  # 200
+    end
+  end
+end


### PR DESCRIPTION
◼︎下記リクエストスペック追加（ステータスの確認のみ）
　・spec/requests/users/confirmations_spec.rb
　・spec/requests/users/omniauth_callbacks_spec.rb
　・spec/requests/users_spec.rb

◼︎上記に伴い下記変更
　・authが見つからなかった場合に着火するfailureメソッドをprivateからpublicに移動。
　・auth認証失敗後のリダイレクト先をnew_user_registration_pathに統一。
