### PR TITLE
feat: add registrasions request spec & refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,17 @@ rubocop-gen-config:  # RuboCopの設定ファイル(.rubocop.yml)を自動生成
 rspec:
 	$(COMPOSE) run --rm $(SERVICE) bundle exec rspec
 
+rspec-focus:  # focusタグが付けられたテストを実行（, :focus do）
+	$(COMPOSE) run --rm $(SERVICE) bundle exec rspec --tag focus
+
 rspec-verbose:  # テスト & 結果をドキュメント形式表示
 	$(COMPOSE) run --rm $(SERVICE) bundle exec rspec --format documentation
 
 rspec-with-coverage:  # テスト & カバレッジレポート生成
 	$(COMPOSE) run --rm $(SERVICE) bundle exec rspec --coverage
+
+rspec-log-fail-fast:  # テスト & リアルタイムでログ表示（最初の失敗で止める）
+	$(COMPOSE) run --rm $(SERVICE) bundle exec rspec --format documentation --fail-fast
 
 # -----その他-----
 build:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  # ログイン後とサインアップ後のリダイレクト先の共通化
   def after_sign_in_path_for(resource)
     if resource.date_of_birth.blank?
       edit_date_of_birth_path
@@ -16,13 +15,15 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_up_path_for(resource)
-    after_sign_in_path_for(resource) # ログイン後と同じパスを利用
+    after_sign_in_path_for(resource)  # ログイン後とユーザー登録後のリダイレクト共通化
   end
 
-  # 生年月日未登録者用のページ移動と処理制御（下記 allowed_paths 内にあるものは可能）
+  # 生年月日未登録者の遷移と処理制御（allowed_paths内にあるものが可能）
   def check_date_of_birth
     if user_signed_in? && current_user.date_of_birth.blank? && !allowed_paths.include?(request.path)
       redirect_to edit_date_of_birth_path, alert: "生年月日を登録してください。"
+    elsif !user_signed_in? && request.path == edit_date_of_birth_path
+      redirect_to new_user_session_path, alert: "ログインしてください。"
     end
   end
 
@@ -30,7 +31,7 @@ class ApplicationController < ActionController::Base
 
   def allowed_paths
     [
-      dashboard_index_path,              # ダッシュボードページ
+      dashboard_index_path,        # ダッシュボードページ
       user_path(current_user),     # アカウント情報ページ
       edit_user_registration_path, # アカウント情報変更ページ
       user_registration_path,      # アカウント情報更新処理

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,81 +1,51 @@
-# frozen_string_literal: true
-
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
-  before_action :configure_permitted_parameters
   before_action :authenticate_user!, only: [ :edit_date_of_birth, :update_date_of_birth ]
-  before_action :set_resource, only: [ :edit_date_of_birth, :update_date_of_birth ]
+  before_action :configure_permitted_parameters
 
   def create
     super do |resource|
       if resource.persisted? && resource.sns_credentials.empty?
-        sign_out resource unless resource.confirmed?  # SNS未使用ユーザー用
+        sign_out resource unless resource.confirmed?  # 一般ユーザー用
       end
     end
   end
 
   def update
     if resource.update(account_update_params)
-      redirect_to user_path(resource), notice: "アカウント情報が更新されました"
+      redirect_to user_path(resource), notice: t("message.devise.registration.update.success")
     else
-      render :edit
+      flash.now[:alert] = t("message.devise.registration.update.failure")
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  def edit_date_of_birth; end  # 生年月日の単体登録ページ
+  def edit_date_of_birth; end
 
-  # 生年月日の単体登録処理
   def update_date_of_birth
-    if current_user.update(date_of_birth_params)
-      redirect_to dashboard_index_path, notice: "生年月日を登録しました。"
+    if user_signed_in?
+      update_date_of_birth_for_user
     else
-      flash.now[:alert] = "生年月日の登録に失敗しました。"
-      render :edit_date_of_birth, status: :unprocessable_entity
+      redirect_to new_user_session_path, alert: t("message.devise.registration.update.not_sign_in")
     end
   end
-
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
-
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
-
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
 
   protected
 
-  # 登録時、更新時の追加のパラメータを許可
+  # 追加パラメータの許可
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :date_of_birth ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :date_of_birth ])
   end
 
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
   private
 
-  def set_resource
-    @resource = current_user
+  def update_date_of_birth_for_user
+    if current_user.update(date_of_birth_params)
+      redirect_to dashboard_index_path, notice: t("message.devise.registration.update_date_of_birth.success")
+    else
+      flash.now[:alert] = t("message.devise.registration.update_date_of_birth.failure")
+      render :edit_date_of_birth, status: :unprocessable_entity
+    end
   end
 
   def date_of_birth_params

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,4 +1,4 @@
-<% if resource.errors.any? %>
+<% if resource && resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
     <p>
       <%= I18n.t("errors.messages.not_saved",

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,14 @@
 ja:
+  message:
+    devise:
+      registration:
+        update:
+          success: "アカウント情報を更新しました。"
+          failure: "アカウント情報を更新できませんでした。"
+        update_date_of_birth:
+          success: "生年月日を登録しました。"
+          failure: "生年月日を登録できませんでした。"
+          not_sign_in: "ログインしてください。"
   notice:
     devise:
       omniauth:

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,23 +1,10 @@
 FactoryBot.define do
   factory :user do
-    transient do
-      date_of_birth { nil } # デフォルトはnil
-    end
-
     name { "テストユーザー" }
     email { "test@example.com" }
     password { "password1234" }
     password_confirmation { password }
     confirmed_at { Time.current }
-
-    initialize_with do
-      dob = Date.today.year - 40
-
-      if attributes[:skip_create]
-        new(attributes.except(:skip_create).merge(date_of_birth: dob))  # buildの場合
-      else
-        new(attributes.except(:skip_create).merge(date_of_birth: Date.new(dob, 1, 1)))  # createの場合
-      end
-    end
+    date_of_birth { Date.new(Date.today.year - 40, 1, 1) }
   end
 end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Registrations", type: :request do
+  let(:user) { create(:user) }
+
+  describe "POST /users" do
+    it "有効なサインアップ後に303を返す" do
+      post user_registration_path, params: { user: attributes_for(:user).except(:confirmed_at) }
+      expect(response).to have_http_status(:see_other)  # 303
+    end
+  end
+
+  describe "PUT /users" do
+    before { sign_in user }
+
+    it "ユーザー情報更新時に302を返す" do
+      put user_registration_path, params: { user: { name: "新しいユーザー名" } }
+      expect(response).to have_http_status(:redirect)  # 302
+    end
+
+    it "ユーザー情報更新失敗時に422を返す" do
+      put user_registration_path, params: { user: { name: nil } }
+      expect(response).to have_http_status(:unprocessable_entity)  # 422
+    end
+  end
+
+  describe "GET /users/date_of_birth/edit" do
+    context "ログイン済の場合" do
+      before { sign_in user }
+
+      it "ページを表示し200を返す" do
+        get edit_date_of_birth_path
+        expect(response).to have_http_status(:success)  # 200
+      end
+    end
+
+    context "未ログインの場合" do
+      before { sign_out user }
+
+      it "ログインページにリダイレクトし302を返す" do
+        get edit_date_of_birth_path
+        expect(response).to have_http_status(:redirect)  # 302
+      end
+    end
+  end
+
+  describe "PATCH /users/date_of_birth" do
+    context "ログイン済の場合" do
+      before { sign_in user }
+
+      it "更新に成功し302を返す" do
+        patch update_date_of_birth_path, params: { user: { date_of_birth: "2000-01-01" } }
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it "不正な値入力では更新失敗し、422を返す" do
+        patch update_date_of_birth_path, params: { user: { date_of_birth: nil } }
+        expect(response).to have_http_status(:unprocessable_entity)  # 422
+      end
+    end
+
+    context "未ログインの場合", :focus do
+      before { sign_out user }
+
+      it "ログインページにリダイレクトし、302を返す" do
+        patch update_date_of_birth_path, params: { user: { date_of_birth: "2000-01-01" } }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+end


### PR DESCRIPTION
◼︎リクエストスペック追加（spec/requests/users/registrations_spec.rb）
　・ステータス確認のみ

◼︎上記に伴うリファクタリング
　app/controllers/users/registrations_controller.rb
　　・メソッド化
　　・メッセージをja.yml管理に変更
　　・set_resourceメソッドと、このメソッドに関連するbefore_actionの削除
　　・不要なコメントアウトの削除

　app/controllers/application_controller.rb
　　・未ログイン時はedit_date_of_birth_pathに遷移を許可しない記述を追加

　app/views/devise/shared/_error_messages.html.erb
　　・resourceが存在する場合のみ resource.errors.any?を呼ぶように変更

　spec/factories/users.rb
　　・不要な記述削除

◼︎Makefileに下記コマンド追加
　・rspec-focus:  # focusタグが付けられたテストを実行（, :focus do）
　・rspec-log-fail-fast:  # テスト & リアルタイムでログ表示（最初の失敗で止める）


