### PR TITLE
fix: update ci.yml for CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,41 +40,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
-
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: .ruby-version
-          bundler-cache: true
+      - name: Docker Compose のセットアップ
+        run: |
+          docker compose -f compose.yml up -d --build db
+          sleep 10 # DBの起動を待機
 
-      - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+      - name: Docker コンテナの起動
+        run: docker compose -f compose.yml up -d --build web
+
+      - name: RSpec 実行
+        run: docker compose exec -T web bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
◼︎CIの導入
　・修正前は、testジョブ内でservicesを使ってPostgresサービスを定義していたが、
　　代わりにDocker Composeを導入し、Webコンテナ内でテストを実行する仕様に変更。
　　開発環境が Docker ベースで統一しているため、CI 環境もそれに合わせるべきだと判断した。
　　また、本番環境（Heroku）とローカル環境（Docker）で違いがあるため、
　　少なくとも開発環境と CI 環境は揃えた方がデバッグしやすくなると判断した。