### PR TITLE
feat: add install dependencies step in CI for Gem management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,23 +40,41 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      # redis:
+      #   image: redis
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Docker Compose のセットアップ
-        run: |
-          docker compose -f compose.yml up -d --build db
-          sleep 10 # DBの起動を待機
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
 
-      - name: Docker コンテナの起動
-        run: docker compose -f compose.yml up -d --build web
-
-      - name: Install dependencies
-        run: docker compose exec -T web bundle install
-
-      - name: RSpec 実行
-        run: docker compose exec -T web bundle exec rspec
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
◼︎.github/workflows/ci.yml
　・アプリケーションが依存しているGemやライブラリを明示的にインストールするため、- name: Install dependenciesを記述追加

◼︎上記を行ったが、serviceを使用したテスト実行に再度変更した。