### PR TITLE
update: asset_lifespan model spec

### DIFF
--- a/spec/models/asset_lifespan_spec.rb
+++ b/spec/models/asset_lifespan_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe AssetLifespan, type: :model do
       let(:lifespan_months) { 1 }
 
       context 'asset_lifespanデータがある場合' do
-        before do
-          asset_lifespan
-        end
+        let!(:asset_lifespan) { create(:asset_lifespan, user: user, simulation: simulation) }
 
         it '既存asset_lifespanデータを更新する' do
           expect do


### PR DESCRIPTION
◼︎モデルスペックの修正
　・asset_lifespanの作成時に明示的にuserとsimulationを紐付け。