### PR TITLE
feat: update AI advice logic & change display location

### DIFF
--- a/app/controllers/life_events_controller.rb
+++ b/app/controllers/life_events_controller.rb
@@ -7,7 +7,10 @@ class LifeEventsController < ApplicationController
     @grouped_life_events = @life_events.group_by {
       |event| calculate_age_group(event.event_date.year, current_user.date_of_birth.year)
     }
-    @memos = current_user.memos.group_by(&:age_group)
+    @memos = current_user.memos.group_by(&:age_group) 
+
+    @advice_record = current_user.ai_advices.last
+    @advice = @advice_record.present? ? @advice_record.content : nil
   end
 
   def new

--- a/app/controllers/openai_advices_controller.rb
+++ b/app/controllers/openai_advices_controller.rb
@@ -1,7 +1,8 @@
 class OpenaiAdvicesController < ApplicationController
   before_action :authenticate_user!
 
-  def show
-    @advice = OpenaiAdviceService.new(current_user).generate_advice
+  def generate_advice
+    @advice = OpenaiAdviceService.new(current_user).generate_and_save_advice
+    redirect_to life_events_path, notice: "アドバイスを更新しました。"
   end
 end

--- a/app/models/ai_advice.rb
+++ b/app/models/ai_advice.rb
@@ -1,0 +1,4 @@
+class AiAdvice < ApplicationRecord
+  belongs_to :user
+  validates :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_one :simulation, dependent: :destroy
   has_many :scenarios, dependent: :destroy
   has_many :asset_lifespans, dependent: :destroy
+  has_many :ai_advices, dependent: :destroy
   has_many :sns_credentials, dependent: :destroy
 
   # カスタムのみ記述（email形式 と password長さは、devise.rb側で定義）

--- a/app/services/openai_advice_service.rb
+++ b/app/services/openai_advice_service.rb
@@ -6,35 +6,78 @@ class OpenaiAdviceService
     @client = OpenAI::Client.new(access_token: Rails.application.credentials.dig(:openai, :api_key))
   end
 
-	def generate_advice
-		prompt = build_prompt
-	
-		response = @client.chat(
-			parameters: {
-				model: "gpt-3.5-turbo",
-				messages: [
-					{ role: "system", content: "あなたは経験豊富なライフプランナーです。" },
-					{ role: "user", content: prompt }
-				],
-				max_tokens: 300,
-				temperature: 0.7
-			}
-		)
-	
-		response.dig("choices", 0, "message", "content") || "アドバイスの生成に失敗しました。"
-	rescue OpenAI::Error => e
-		"OpenAI APIエラー: #{e.message}"
-	rescue StandardError => e
-		"エラーが発生しました: #{e.message}"
-	end
+  def generate_and_save_advice
+    existing_advice = @user.ai_advices.last
+    new_advice_content = generate_advice_from_openai # OpenAI API を呼び出して新しいアドバイスを取得
 
-  private
+    if existing_advice.present?
+      existing_advice.update!(content: new_advice_content)  # 既存のアドバイスを更新
+    else
+      @user.ai_advices.create!(content: new_advice_content) # 新規作成
+    end
 
-  def build_prompt
+    new_advice_content
+  end
+
+	private
+
+  def generate_advice_from_openai
+    financial_forecast = generate_financial_data(@user)
+    prompt = build_prompt(financial_forecast)
+
+    response = @client.chat(
+      parameters: {
+        model: "gpt-3.5-turbo",
+        messages: [
+          { role: "system", content: "あなたは経験豊富なライフプランナーです。" },
+          { role: "user", content: prompt }
+        ],
+        max_tokens: 300,
+        temperature: 0.7
+      }
+    )
+
+    response.dig("choices", 0, "message", "content") || "アドバイスの生成に失敗しました。"
+  rescue OpenAI::Error => e
+    "OpenAI APIエラー: #{e.message}"
+  rescue StandardError => e
+    "エラーが発生しました: #{e.message}"
+  end
+
+  def build_prompt(financial_forecast)
+    current_age = @user.calculate_user_age
+    forecast_str = financial_forecast.map { |age, amount| "#{age}代:#{amount}万円" }.join("、")
+
     <<~PROMPT
-      総資産額100万円を持つ30歳です。
-			5年以内に300万円の車を買うには、どのような計画を立てればよいでしょうか？
-			実行可能なアドバイスを日本語で200字以内でください。
+      私は現在#{current_age}歳です。
+      ライフイベントを考慮すると、今後の収支状況は下記となる見込みです。
+      どのようなプランをいつ実行すれば、改善できるかを下記情報を元に教えてください。
+      回答は、理由と特に注意すべき時期を含めて、300字以内の日本語でお願いいたします。
+      誰でも理解しやすい単語や文章にしてください。
+      #{forecast_str}
     PROMPT
+  end
+
+  def generate_financial_data(user)
+    current_age = user.calculate_user_age
+    current_year = Date.today.year
+
+    scenario = user.scenarios.find_by(scenario_type: "現実") # "現実"のシナリオを取得
+    balance_scenario = scenario&.balance_scenario || [] # balance_scenarioを取得
+
+    financial_data = Hash.new(0)  # 年代ごとの収支を格納するハッシュ
+
+    balance_scenario.each do |entry|
+      year = entry["date"]
+      amount = entry["amount"]
+
+      # その年のユーザーの年齢を計算
+      age_at_year = current_age + (year - current_year)
+      age_group = (age_at_year / 10) * 10 # 30代, 40代, 50代... に分類
+
+      financial_data[age_group] += amount  # 該当する年代の合計収支を更新
+    end
+
+    financial_data
   end
 end

--- a/app/views/life_events/index.html.erb
+++ b/app/views/life_events/index.html.erb
@@ -6,6 +6,10 @@
     <h4 class="mb-3">プランの具体化</h4>
     <p>今後の計画や目標などをメモに整理しましょう。</p>
   </div>
+  <div>
+    <%= render "openai_advices/show", advice: @advice || "アドバイスがまだありません。" %>
+  </div>
+  
   <% @age_groups_to_display.each do |age_group| %>
     <div class="card mb-3">
       <div class="card-body">

--- a/app/views/openai_advices/_show.html.erb
+++ b/app/views/openai_advices/_show.html.erb
@@ -1,0 +1,8 @@
+<h2>あなたへのアドバイス</h2>
+<% if @advice.nil? %>
+	<p>情報入力が完了していないため、アドバイスを作成できません。</p>
+<% else %>
+	<p><%= @advice %></p>
+<% end %>
+
+<%= button_to 'アドバイス更新', generate_advice_openai_advice_path, method: :post, class: "btn btn-primary" %>

--- a/app/views/openai_advices/show.html.erb
+++ b/app/views/openai_advices/show.html.erb
@@ -1,3 +1,0 @@
-<h2>あなたへのアドバイス</h2>
-<p><%= @advice %></p>
-<%= link_to "再生成", openai_advice_path, method: :get, class: "btn btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,11 @@ Rails.application.routes.draw do
   resources :memos, only: [ :create, :update ]
 
   # openai_advice関連
-  resource :openai_advice, only: [:show]
+  resource :openai_advice, only: [:show] do
+    collection do
+      post :generate_advice
+    end
+  end
 
   root to: "home#index"  # home関連（トップページ）
   get "dashboard/index"  # ダッシュボード

--- a/db/migrate/20250218073306_create_ai_advices.rb
+++ b/db/migrate/20250218073306_create_ai_advices.rb
@@ -1,0 +1,10 @@
+class CreateAiAdvices < ActiveRecord::Migration[7.2]
+  def change
+    create_table :ai_advices do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_29_144856) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_18_073306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ai_advices", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_ai_advices_on_user_id"
+  end
 
   create_table "asset_lifespans", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -147,6 +155,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_144856) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "ai_advices", "users"
   add_foreign_key "asset_lifespans", "simulations"
   add_foreign_key "asset_lifespans", "users"
   add_foreign_key "incomes", "simulations"

--- a/spec/factories/ai_advices.rb
+++ b/spec/factories/ai_advices.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :ai_advice do
+    user { nil }
+    content { "MyText" }
+  end
+end

--- a/spec/models/ai_advice_spec.rb
+++ b/spec/models/ai_advice_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AiAdvice, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
◼︎AIアドバイスを保存するai_advicesテーブルの作成
　・これまでは、毎回APIリクエストをしてアドバイスを取得していたが、
　　データがある場合は、DBからデータ取得する仕様に変更。
　※ いつどのような状況であれば新しいアドバイスを取得するかを実装する必要あり。
　
　・Userにリレーション追加。

◼︎AIアドバイスの表示に関する変更
　・life_event_controllerで最新のアドバイスデータを取得し変数に代入。
　・アドバイスを表示するページであるlife_events/indexでは、
　　コントローラーの変数をパーシャル(openai_advices/_show.html.erb)に渡し表示する。
　・openai_advices_controllerのshowアクションは上記により、不要となったため、削除。

◼︎services/openai_advice_service.rb内のプロンプト作成ロジックの修正
　・テスト用に記述していた文章を改善し、文章内で使用する値を動的に出力できる仕様に変更した。
　※カプセル化や責務委譲の問題があるため、改善をする必要がある。

◼︎specファイル追加（自動生成）
　・今後テストを追加予定。