### PR TITLE
feat: implement openai request limit & adjust layout

### DIFF
--- a/app/controllers/life_events_controller.rb
+++ b/app/controllers/life_events_controller.rb
@@ -7,7 +7,7 @@ class LifeEventsController < ApplicationController
     @grouped_life_events = @life_events.group_by {
       |event| calculate_age_group(event.event_date.year, current_user.date_of_birth.year)
     }
-    @memos = current_user.memos.group_by(&:age_group) 
+    @memos = current_user.memos.group_by(&:age_group)
 
     @advice_record = current_user.ai_advices.last
     @advice = @advice_record.present? ? @advice_record.content : nil

--- a/app/services/openai_advice_service.rb
+++ b/app/services/openai_advice_service.rb
@@ -1,25 +1,35 @@
-require 'openai'
+require "openai"
 
 class OpenaiAdviceService
   def initialize(user)
     @user = user
-    @client = OpenAI::Client.new(access_token: Rails.application.credentials.dig(:openai, :api_key))
+    @client = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY", Rails.application.credentials.dig(:openai, :api_key)))
   end
 
   def generate_and_save_advice
-    existing_advice = @user.ai_advices.last
-    new_advice_content = generate_advice_from_openai # OpenAI API を呼び出して新しいアドバイスを取得
+    return "今月のアドバイス取得回数の上限に達しました。" if advice_request_limit_reached?
 
-    if existing_advice.present?
-      existing_advice.update!(content: new_advice_content)  # 既存のアドバイスを更新
-    else
-      @user.ai_advices.create!(content: new_advice_content) # 新規作成
-    end
+    scenario = @user.scenarios.find_by(scenario_type: "現実")
+    balance_scenario = scenario&.balance_scenario
+    return "データ入力がないため、アドバイスを生成できません。" if balance_scenario.blank? # nil or 空ならエラーを返す
+
+    new_advice_content = generate_advice_from_openai
+
+    last_scenario_updated = @user.ai_advices.last&.real_scenario_updated_at
+    scenario_table_updated = scenario&.updated_at
+    return "シナリオの更新がありません。" if last_scenario_updated == scenario_table_updated
+
+    @user.ai_advices.create!(content: new_advice_content, real_scenario_updated_at: scenario_table_updated)
 
     new_advice_content
   end
 
-	private
+  private
+
+  def advice_request_limit_reached?
+    start_of_month = Time.zone.now.beginning_of_month
+    @user.ai_advices.where("created_at >= ?", start_of_month).count >= 5
+  end
 
   def generate_advice_from_openai
     financial_forecast = generate_financial_data(@user)
@@ -49,12 +59,13 @@ class OpenaiAdviceService
     forecast_str = financial_forecast.map { |age, amount| "#{age}代:#{amount}万円" }.join("、")
 
     <<~PROMPT
-      私は現在#{current_age}歳です。
-      ライフイベントを考慮すると、今後の収支状況は下記となる見込みです。
-      どのようなプランをいつ実行すれば、改善できるかを下記情報を元に教えてください。
-      回答は、理由と特に注意すべき時期を含めて、300字以内の日本語でお願いいたします。
-      誰でも理解しやすい単語や文章にしてください。
-      #{forecast_str}
+      私は現在#{current_age}歳で、70歳で無職になります。
+      今後の収支状況は次のようになる見込みです。
+      収支状況：#{forecast_str}#{'  '}
+      上記の収支状況を評価した上で、今後の計画を立てるには何から考えると良いか、どんな目標を立てると良いかを上記の収支状況をもとにアドバイスをしてください。
+      回答はどんな読み手でも理解しやすい、300字以内の日本語の文章にまとめてください。
+      共有されていないライフイベントと70代以降の収支の減少については言及しないでください。
+      70代までのマイナス収支があれば、特に考慮してください。
     PROMPT
   end
 
@@ -62,18 +73,18 @@ class OpenaiAdviceService
     current_age = user.calculate_user_age
     current_year = Date.today.year
 
-    scenario = user.scenarios.find_by(scenario_type: "現実") # "現実"のシナリオを取得
-    balance_scenario = scenario&.balance_scenario || [] # balance_scenarioを取得
+    scenario = user.scenarios.find_by(scenario_type: "現実")
+    balance_scenario = scenario&.balance_scenario || []
 
-    financial_data = Hash.new(0)  # 年代ごとの収支を格納するハッシュ
+    financial_data = Hash.new(0)
 
     balance_scenario.each do |entry|
       year = entry["date"]
       amount = entry["amount"]
 
-      # その年のユーザーの年齢を計算
+      # その年の年齢の計算
       age_at_year = current_age + (year - current_year)
-      age_group = (age_at_year / 10) * 10 # 30代, 40代, 50代... に分類
+      age_group = (age_at_year / 10) * 10 # 30代,40代,50代... に分類
 
       financial_data[age_group] += amount  # 該当する年代の合計収支を更新
     end

--- a/app/views/life_events/index.html.erb
+++ b/app/views/life_events/index.html.erb
@@ -1,19 +1,20 @@
 <% content_for :title do %>LifePlan<% end %>
 
 <div class="container">
-  <div class="mb-5">
+  <div class="mb-5 text-center">
     <h1 class="display-4">LifePlan</h1>
     <h4 class="mb-3">プランの具体化</h4>
     <p>今後の計画や目標などをメモに整理しましょう。</p>
   </div>
-  <div>
-    <%= render "openai_advices/show", advice: @advice || "アドバイスがまだありません。" %>
-  </div>
-  
+
+  <%= render "openai_advices/show", advice: @advice %>
+
   <% @age_groups_to_display.each do |age_group| %>
     <div class="card mb-3">
-      <div class="card-body">
+      <div class="card-header">
         <h3><%= age_group %>代</h3>
+      </div>
+      <div class="card-body">
         <div class="row">
           <div class="col-md-5">
             <% if @grouped_life_events[age_group].blank? %>

--- a/app/views/openai_advices/_show.html.erb
+++ b/app/views/openai_advices/_show.html.erb
@@ -1,8 +1,17 @@
-<h2>あなたへのアドバイス</h2>
-<% if @advice.nil? %>
-	<p>情報入力が完了していないため、アドバイスを作成できません。</p>
-<% else %>
-	<p><%= @advice %></p>
-<% end %>
-
-<%= button_to 'アドバイス更新', generate_advice_openai_advice_path, method: :post, class: "btn btn-primary" %>
+<div class="card mb-3">
+  <div class="card-header d-flex align-items-center">
+    <h4 class="mt-2">アドバイス</h4>
+    <%= button_to '生成する', generate_advice_openai_advice_path, method: :post, class: "btn btn-outline-primary btn-sm ms-3" %>
+  </div>
+  <div class="card-body">
+    <% if @advice.nil? %>
+      <p class="text-muted">情報入力の上、「生成する」ボタンを押してください。</p>
+    <% else %>
+      <p>
+        <%= @advice %>
+        <br>
+        <small class="text-muted">※現実的シナリオを基準とした経済面のアドバイスです。</small>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
   resources :memos, only: [ :create, :update ]
 
   # openai_advice関連
-  resource :openai_advice, only: [:show] do
+  resource :openai_advice, only: [] do
     collection do
       post :generate_advice
     end

--- a/db/migrate/20250219060927_add_real_scenario_updated_at_to_ai_advices.rb
+++ b/db/migrate/20250219060927_add_real_scenario_updated_at_to_ai_advices.rb
@@ -1,0 +1,5 @@
+class AddRealScenarioUpdatedAtToAiAdvices < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ai_advices, :real_scenario_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_18_073306) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_19_060927) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_18_073306) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "real_scenario_updated_at"
     t.index ["user_id"], name: "index_ai_advices_on_user_id"
   end
 


### PR DESCRIPTION
◼︎rubocopのlint修正　（app/controllers/life_events_controller.rb）

◼︎AIアドバイス機能の修正
　・リクエスト制限を設置（１ユーザーにつき５回 / 月）
　・scenarioデータの更新がない場合はリクエストを送らず、DBに保存したアドバイスを表示する仕様に変更。
　　・ai_advicesテーブルにreal_scenario_updated_atを追加
　　※ null: false設定追加の必要あり。
　・プロンプトの修正
　　※退職時期を動的にする必要あり。
　・不要なルーティング削除
　・heroku環境変数をweb上で追加し、service.rb内の環境変数取得処理を変更。
　　・開発環境ではcredentialsから、本番環境ではheroku環境変数から取得。

◼︎ビュー調整
　・life_events/index　：card-headerで年代表示をするように修正
　・openai_advices/_show　：bootstrapスタイルの適用