### PR TITLE
feat: service_spec for openai_advice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ group :development, :test do
   gem "rspec-rails", "~> 7.1"
   gem "factory_bot_rails", "~> 6.4"
   gem "shoulda-matchers", "~> 5.0"
+
+  # debug関連
+  gem "pry"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     chartkick (5.1.2)
     childprocess (5.1.0)
       logger (~> 1.5)
+    coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -189,6 +190,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.3)
@@ -247,6 +249,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.8)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.2.2)
       date
       stringio
@@ -432,6 +437,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 1.0)
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  pry
   puma (>= 5.0)
   rails (~> 7.2.1, >= 7.2.1.1)
   rspec-rails (~> 7.1)

--- a/app/models/ai_advice.rb
+++ b/app/models/ai_advice.rb
@@ -1,4 +1,5 @@
 class AiAdvice < ApplicationRecord
   belongs_to :user
   validates :content, presence: true
+  validates :real_scenario_updated_at, presence: true
 end

--- a/app/services/openai_advice_service.rb
+++ b/app/services/openai_advice_service.rb
@@ -16,6 +16,7 @@ class OpenaiAdviceService
     return "シナリオの更新がありません。" unless scenario_updated?
 
     new_advice_content = generate_advice_from_openai
+    return new_advice_content if new_advice_content.start_with?("OpenAI APIエラー:", "エラーが発生しました:")
     @user.ai_advices.create!(content: new_advice_content, real_scenario_updated_at: @scenario.updated_at)
 
     "アドバイスを生成しました。" # 成功時のメッセージを返す

--- a/spec/factories/ai_advices.rb
+++ b/spec/factories/ai_advices.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :ai_advice do
-    user { nil }
-    content { "MyText" }
+    user
+    content { "サンプルアドバイス" }
+    real_scenario_updated_at { Time.zone.now }
   end
 end

--- a/spec/factories/scenarios.rb
+++ b/spec/factories/scenarios.rb
@@ -2,13 +2,14 @@ FactoryBot.define do
   factory :scenario do
     user
     simulation
-    scenario_type { nil }
+    scenario_type { "現実" }
     total_income { nil }
     total_expense { nil }
     total_balance { nil }
     asset_scenario { nil }
-    balance_scenario { nil }
+    balance_scenario { [ { "date" => 2000, "amount" => 100 } ] }
     withdrawal { nil }
     shortage { nil }
+    updated_at { 1.day.ago }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,11 @@ FactoryBot.define do
     password_confirmation { password }
     confirmed_at { Time.current }
     date_of_birth { Date.new(Date.today.year - 40, 1, 1) }
+
+    # user作成時のscenarioデータ作成を抑制する必要がある特定のテストに使用。下記のように呼び出す。
+    # let!(:user) { create(:user, :without_scenarios) }
+    trait :without_scenarios do
+      after(:create) { |user| user.scenarios.delete_all }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
+require 'pry'
 require 'rspec/rails'
 require 'factory_bot_rails'
 

--- a/spec/services/openai_advice_service_spec.rb
+++ b/spec/services/openai_advice_service_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe OpenaiAdviceService do
+  let!(:user) { create(:user, :without_scenarios) } # シナリオデータの自動生成を抑制
+  let!(:simulation) { create(:simulation, user: user) }
+  let!(:scenario) { create(:scenario, user: user, simulation: simulation,  updated_at: 1.day.ago) }
+  let(:service) { described_class.new(user) }
+  let(:balance_scenario) { [ { "date" => Date.today.year, "amount" => 100 } ] }
+
+  before do
+    allow(user).to receive(:scenarios).and_return(Scenario.where(user: user))
+    allow(user).to receive(:calculate_user_age).and_return(30)
+    allow(scenario).to receive(:balance_scenario).and_return(balance_scenario)
+  end
+
+  describe "#generate_and_save_advice" do
+    context "リクエスト制限回数を超える場合" do
+      before do
+        create_list(:ai_advice, OpenaiAdviceService::ADVICE_LIMIT_PER_MONTH, user: user, created_at: Time.zone.now.beginning_of_month + 1.hour)
+      end
+
+      it "処理を中断し、上限到達メッセージを返す" do
+        expect(service.generate_and_save_advice).to eq("今月のアドバイス取得回数の上限に達しました。")
+      end
+    end
+
+    context "scenariosテーブルのbalance_dataがない場合" do
+      before do
+        allow(user).to receive(:scenarios).and_return(Scenario.none)
+      end
+
+      it "処理を中断し、データなしのメッセージを返す" do
+        expect(service.generate_and_save_advice).to eq("データ入力がないため、アドバイスを生成できません。")
+      end
+    end
+
+    context "scenariosテーブル内容の変更がない場合" do
+      before do
+        allow(user).to receive(:scenarios).and_return(Scenario.where(id: scenario.id))
+        allow(scenario).to receive(:balance_scenario).and_return(balance_scenario)
+        create(:ai_advice, user: user, real_scenario_updated_at: scenario.updated_at)
+      end
+
+      it "処理を中断し、変更がない旨のメッセージを返す" do
+        expect(service.generate_and_save_advice).to eq("シナリオの更新がありません。")
+      end
+    end
+
+    context "OpenAI APIが正常にレスポンスする場合" do
+      let(:mock_openai_response) do
+        { "choices" => [ { "message" => { "content" => "これはサンプルのアドバイスです。" } } ] }
+      end
+
+      before do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(mock_openai_response)
+        create(:ai_advice, user: user, real_scenario_updated_at: 2.day.ago)
+      end
+
+      it "アドバイスを生成し成功メッセージを返す", :focus do
+        expect { service.generate_and_save_advice }.to change { user.ai_advices.count }.by(1)
+        expect(user.ai_advices.last.content).to eq("これはサンプルのアドバイスです。")
+        expect(service.generate_and_save_advice).to eq("アドバイスを生成しました。")
+      end
+    end
+
+    context "when OpenAI API returns an error" do
+      before do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(OpenAI::Error.new("APIエラー"))
+      end
+
+      it "returns an error message" do
+        expect(service.generate_and_save_advice).to eq("OpenAI APIエラー: APIエラー")
+      end
+    end
+
+    context "when an unexpected error occurs" do
+      before do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(StandardError.new("予期しないエラー"))
+      end
+
+      it "returns a generic error message" do
+        expect(service.generate_and_save_advice).to eq("エラーが発生しました: 予期しないエラー")
+      end
+    end
+  end
+end


### PR DESCRIPTION
◼︎openai_adviceのservice specを追加
　上記に伴い、
　・openai_advice modelにreal_scenario_updated_atのバリデーション追加。
　・generate_advice_from_openaiメソッド実行時のエラーを返すよう修正。
　・デバッグ効率化のため、gem "pry"をインストール。