### PR TITLE
chore: rename directory from portfolio to scenapla

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password # 変更
-          POSTGRES_DB: myapp_test  # 変更（指定）
+          POSTGRES_DB: scenapla_test  # 変更（指定）
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready -U postgres -d postgres" --health-interval=10s --health-timeout=5s --health-retries=5
@@ -82,8 +82,8 @@ jobs:
         env:
           RAILS_ENV: test
           #DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          #DATABASE_URL: postgres://postgres:postgres@localhost:5432/myapp_test
-          DATABASE_URL: postgres://postgres:password@localhost:5432/myapp_test # 変更
+          #DATABASE_URL: postgres://postgres:postgres@localhost:5432/scenapla_test
+          DATABASE_URL: postgres://postgres:password@localhost:5432/scenapla_test # 変更
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
         run: bundle exec rspec

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,7 @@ RUN apt-get update -qq \
 && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim
-RUN mkdir /myapp
-WORKDIR /myapp
+RUN mkdir /scenapla
+WORKDIR /scenapla
 RUN gem install bundler
-COPY . /myapp
+COPY . /scenapla

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "Myapp",
+  "name": "Scenapla",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "Myapp.",
+  "description": "Scenapla.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 require "fileutils"
 
 APP_ROOT = File.expand_path("..", __dir__)
-APP_NAME = "myapp"
+APP_NAME = "scenapla"
 
 def system!(*args)
   system(*args, exception: true)

--- a/compose.yml
+++ b/compose.yml
@@ -11,8 +11,8 @@ services:
     ports:
       - 5432:5432
     healthcheck:
-      # test: ["CMD-SHELL", "pg_isready -d myapp_development -U postgres"]
-      test: ["CMD-SHELL", "pg_isready -d myapp_test -U postgres"]
+      # test: ["CMD-SHELL", "pg_isready -d scenapla_development -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -d scenapla_test -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -25,9 +25,9 @@ services:
     tty: true
     stdin_open: true
     volumes:
-      - .:/myapp
+      - .:/scenapla
       - bundle_data:/usr/local/bundle:cached
-      - node_modules:/myapp/node_modules
+      - node_modules:/scenapla/node_modules
     environment:
       TZ: Asia/Tokyo
     ports:

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Myapp
+module Scenapla
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: myapp_production
+  channel_prefix: scenapla_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ default: &default
 
 development:
   <<: *default
-  database: myapp_development
+  database: scenapla_development
   host: db
   username: postgres
   password: password
@@ -18,7 +18,7 @@ development:
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role.
   # This is the same name as the operating system user running Rails.
-  # username: myapp
+  # username: scenapla
 
   # The password associated with the PostgreSQL role (username).
   # password:
@@ -32,7 +32,7 @@ development:
   # port: 5432
 
   # Schema search path. The server defaults to $user,public
-  # schema_search_path: myapp,sharedapp,public
+  # schema_search_path: scenapla,sharedapp,public
 
   # Minimum log levels, in increasing order: debug5, debug4, debug3, debug2, debug1, log, notice, warning, error, fatal, and panic
   # Defaults to warning.
@@ -42,7 +42,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: myapp_test
+  database: scenapla_test
   host: db
   username: postgres
   password: password

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "myapp_production"
+  # config.active_job.queue_name_prefix = "scenapla_production"
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.


### PR DESCRIPTION
◼︎リモートとローカルのリポジトリ名を「scenapla」に変更。
　上記に伴い、データベース名も「scenapla」に統一。