### PR TITLE
fix: update references for new column name

### DIFF
--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -14,7 +14,7 @@ class Scenario < ApplicationRecord
 
   # シナリオ更新
   def update_scenario_data!
-    life_event_data = (scenario_type == "現実") ? simulation.real_life_event_data : simulation.ideal_life_event_data
+    life_event_data = (scenario_type == "現実") ? simulation.real_event_data : simulation.ideal_event_data
     calculated_data = Simulation.calculate_scenario_data(simulation, life_event_data)
     update!(calculated_data)
 

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -28,8 +28,8 @@ class Simulation < ApplicationRecord
   def update_life_event_data!(user)
     life_event_data = LifeEvent.generate_life_event_data_for(user)
     update!(
-      real_life_event_data: life_event_data[:real_event_data].presence,
-      ideal_life_event_data: life_event_data[:ideal_event_data].presence
+      real_event_data: life_event_data[:real_event_data].presence,
+      ideal_event_data: life_event_data[:ideal_event_data].presence
     )
   end
 
@@ -41,7 +41,7 @@ class Simulation < ApplicationRecord
     total_income = simulation.get_total_income
 
     datasets = [ simulation.expense_data, life_event_data ]
-    datasets << simulation.real_life_event_data if life_event_data != simulation.real_life_event_data
+    datasets << simulation.real_event_data if life_event_data != simulation.real_event_data
     total_expense = simulation.get_total_expense(*datasets)
 
     total_balance = total_income + total_expense

--- a/spec/factories/simulations.rb
+++ b/spec/factories/simulations.rb
@@ -1,11 +1,10 @@
 FactoryBot.define do
   factory :simulation do
     user
-    inflation_rate { 1.5 }
     income_data { nil }
     expense_data { nil }
     user_asset_data { nil }
-    real_life_event_data { nil }
-    ideal_life_event_data { nil }
+    real_event_data { nil }
+    ideal_event_data { nil }
   end
 end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Scenario, type: :model do
 
     describe '#update_scenario_data!' do
       before do
-        allow(simulation).to receive(:real_life_event_data).and_return('real_data')
-        allow(simulation).to receive(:ideal_life_event_data).and_return('ideal_data')
+        allow(simulation).to receive(:real_event_data).and_return('real_data')
+        allow(simulation).to receive(:ideal_event_data).and_return('ideal_data')
         allow(Simulation).to receive(:calculate_scenario_data).with(simulation, 'real_data').and_return({ result: 'updated_real_data' })
         allow(Simulation).to receive(:calculate_scenario_data).with(simulation, 'ideal_data').and_return({ result: 'updated_ideal_data' })
       end

--- a/spec/models/simulation_spec.rb
+++ b/spec/models/simulation_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Simulation, type: :model do
         allow(simulation).to receive(:merged_income_expense_event).with(life_event_data).and_return({ "date"=>2000, "amount"=>100 })
         allow(simulation).to receive(:get_total_income).and_return(2000)
 
-        # life_event_dataにreal_life_event_data入っていない場合を想定
+        # life_event_dataにreal_event_data入っていない場合を想定
         simulation.expense_data = [ { "date"=>2000, "amount"=>100 } ]
-        simulation.real_life_event_data = [ { "date"=>2000, "amount"=>100 } ]
-        valid_datasets = [ simulation.expense_data, life_event_data, simulation.real_life_event_data ]
+        simulation.real_event_data = [ { "date"=>2000, "amount"=>100 } ]
+        valid_datasets = [ simulation.expense_data, life_event_data, simulation.real_event_data ]
         allow(simulation).to receive(:get_total_expense).with(*valid_datasets).and_return(-1000)
 
         allow(simulation).to receive(:get_monthly_expense).and_return(20)
@@ -190,8 +190,8 @@ RSpec.describe Simulation, type: :model do
 
       it '#update_life_event_data!' do
         simulation.update_life_event_data!(user)
-        expect(simulation.real_life_event_data).to eq({ "date"=>2010, "amount"=>100 })
-        expect(simulation.ideal_life_event_data).to eq({ "date"=>2020, "amount"=>200 })
+        expect(simulation.real_event_data).to eq({ "date"=>2010, "amount"=>100 })
+        expect(simulation.ideal_event_data).to eq({ "date"=>2020, "amount"=>200 })
       end
     end
 


### PR DESCRIPTION
◼︎simulationsテーブルのカラム名変更、カラム削除に伴う、関連箇所の記述修正。
　・real_event_data, ideal_event_dataを書く箇所に適用。
　・ファクトリ内のinflation_rate削除。