### PR TITLE
fix: update references for new column

### DIFF
--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -2,7 +2,7 @@ class Scenario < ApplicationRecord
   belongs_to :user
   belongs_to :simulation
 
-  enum scenario_type: { 現実: "現実", 理想: "理想" }
+  enum scenario_type: { 現実: 0, 理想: 1 }
 
   validates :user_id, :simulation_id, presence: true
 

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Scenario, type: :model do
 
   describe 'enumテスト' do
     it 'scenario_typeが正しい値を持つ' do
-      expect(described_class.scenario_types).to eq({ '現実' => '現実', '理想' => '理想' })
+      expect(described_class.scenario_types).to eq({ '現実' => 0, '理想' => 1 })
     end
   end
 


### PR DESCRIPTION
◼︎scenariosテーブルのscenario_typeのデータ型変更に伴う、関連する記述箇所修正。