### PR TITLE
refactor: organize ai_advices table and migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ up:
 down:
 	$(COMPOSE) down
 
+restart:
+	$(COMPOSE) restart
+
 logs:  # コンテナのログをリアルタイム表示
 	$(COMPOSE) logs -f
 

--- a/db/migrate/20250219060927_add_real_scenario_updated_at_to_ai_advices.rb
+++ b/db/migrate/20250219060927_add_real_scenario_updated_at_to_ai_advices.rb
@@ -1,5 +1,0 @@
-class AddRealScenarioUpdatedAtToAiAdvices < ActiveRecord::Migration[7.2]
-  def change
-    add_column :ai_advices, :real_scenario_updated_at, :datetime
-  end
-end

--- a/db/migrate/20250228195519_create_ai_advices.rb
+++ b/db/migrate/20250228195519_create_ai_advices.rb
@@ -2,8 +2,8 @@ class CreateAiAdvices < ActiveRecord::Migration[7.2]
   def change
     create_table :ai_advices do |t|
       t.references :user, null: false, foreign_key: true
-      t.text :content
-
+      t.text "content", null: false
+      t.datetime "real_scenario_updated_at", null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_28_173837) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_28_195519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "ai_advices", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.text "content"
+    t.text "content", null: false
+    t.datetime "real_scenario_updated_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "real_scenario_updated_at"
     t.index ["user_id"], name: "index_ai_advices_on_user_id"
   end
 


### PR DESCRIPTION
◼︎ai_advicesテーブルと、それに関連するマイグレーションの整理。
　・contentとreal_scenario_updated_atカラムにnull: falseを設定。

◼︎makefileにdocker compose restartコマンドを追加。