### PR TITLE
feat: update image path & add UTF-8

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,23 +2,26 @@
 <html>
   <head>
     <title><%= content_for(:title) || "Scenapla" %></title>
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="description" content="このアプリは、経済とライフイベントの計画をサポートするツールです。">
   
-    <!-- OGP Tags (固定値) -->
+    <!-- OGP -->
     <meta property="og:title" content="Scenapla">
     <meta property="og:description" content="このアプリは、経済とライフイベントの計画をサポートするツールです。">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://scenapla.com">  <!-- トップページURL -->
     <meta property="og:image" content="<%= asset_url('default-ogp-image.png') %>">  <!-- OGP用画像 -->
     <meta property="og:site_name" content="Scenapla">
+    <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@scenapla">
     <meta name="twitter:title" content="Scenapla">
     <meta name="twitter:description" content="このアプリは、経済とライフイベントの計画をサポートするツールです。">
-    <meta name="twitter:image" content="<%= asset_path('default-ogp-image.png') %>">
+    <meta name="twitter:image" content="<%= asset_url('default-ogp-image.png') %>">
     <meta property="fb:app_id" content="<%= facebook_app_id %>">
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
◼︎metaタグの画像部分のパス変更
　・image_url → asset_url（絶対パスを使用するため）

◼︎ウェブページ文字化けを防ぐため、ウェブページの文字エンコーディングを UTF-8 に設定。