### PR TITLE
refactor: improve logic & tests for life event data

### DIFF
--- a/app/models/life_event.rb
+++ b/app/models/life_event.rb
@@ -19,15 +19,12 @@ class LifeEvent < ApplicationRecord
     ideal_events = life_events.where(event_type: 1)
 
     real_event_data = aggregate_event_data(real_events)
-    ideal_event_data = aggregate_combined_event_data(real_events, ideal_events) if ideal_events.present?
+    ideal_event_data = aggregate_event_data(real_events + ideal_events) if ideal_events.present?
 
-    # 更新用に返す
     { real_event_data: real_event_data, ideal_event_data: ideal_event_data }
   end
 
   private
-
-  # -----共通処理-----
 
   def self.aggregate_event_data(events)
     year_amounts = extract_yearly_amounts(events)
@@ -44,21 +41,6 @@ class LifeEvent < ApplicationRecord
 
   def self.aggregate_by_year(year_amounts)
     year_amounts.group_by { |event| event[:date] }.transform_values do |events|
-      events.sum { |event| event[:amount] }
-    end.map { |year, amount| { date: year, amount: amount } }
-  end
-
-  # -----理想データ作成時のみ使用-----
-
-  def self.aggregate_combined_event_data(real_events, ideal_events)
-    real_data = aggregate_event_data(real_events)
-    ideal_data = aggregate_event_data(ideal_events)
-    merge_yearly_amounts(real_data, ideal_data)
-  end
-
-  def self.merge_yearly_amounts(real_data, ideal_data)
-    combined_data = (real_data + ideal_data).group_by { |event| event[:date] }
-    combined_data.transform_values do |events|
       events.sum { |event| event[:amount] }
     end.map { |year, amount| { date: year, amount: amount } }
   end

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -41,7 +41,6 @@ class Simulation < ApplicationRecord
     total_income = simulation.get_total_income
 
     datasets = [ simulation.expense_data, life_event_data ]
-    datasets << simulation.real_event_data if life_event_data != simulation.real_event_data
     total_expense = simulation.get_total_expense(*datasets)
 
     total_balance = total_income + total_expense

--- a/spec/models/life_event_spec.rb
+++ b/spec/models/life_event_spec.rb
@@ -90,42 +90,53 @@ RSpec.describe LifeEvent, type: :model do
 
   describe ".generate_life_event_data_for" do
     let(:life_events) { double('life_events') }
-    let(:real_events) { double('real_events') }
-    let(:ideal_events) { double('ideal_events') }
-    let(:real_event_data) { { some: 'data' } }
-    let(:ideal_event_data) { { other: 'data' } }
+    let(:real_events) { [ double('real_event1'), double('real_event2') ] }
+    let(:ideal_events) { [ double('ideal_event1'), double('ideal_event2') ] }
+    let(:real_event_data) { { some: 'real_data' } }
+    let(:ideal_event_data) { { some: 'ideal_data' } }
 
     before do
       allow(described_class).to receive(:where).with(user: user).and_return(life_events)
       allow(life_events).to receive(:where).with(event_type: 0).and_return(real_events)
       allow(life_events).to receive(:where).with(event_type: 1).and_return(ideal_events)
       allow(described_class).to receive(:aggregate_event_data).with(real_events).and_return(real_event_data)
-      allow(described_class).to receive(:aggregate_combined_event_data).with(real_events, ideal_events).and_return(ideal_event_data)
     end
 
-    it "内部メソッドが正しく呼ばれ戻り値を返す" do
-      result = described_class.generate_life_event_data_for(user)
+    context "ideal_eventsが存在する場合" do
+      before do
+        allow(ideal_events).to receive(:present?).and_return(true)
+        allow(described_class).to receive(:aggregate_event_data).with(real_events + ideal_events).and_return(ideal_event_data)
+      end
 
-      # where
-      expect(described_class).to have_received(:where).with(user: user)
-      expect(life_events).to have_received(:where).with(event_type: 0)
-      expect(life_events).to have_received(:where).with(event_type: 1)
+      it "内部メソッドが正しく呼ばれ、結合された理想データを返す" do
+        result = described_class.generate_life_event_data_for(user)
 
-      # aggregate_event_data と aggregate_combined_event_data
-      expect(described_class).to have_received(:aggregate_event_data).with(real_events)
-      expect(described_class).to have_received(:aggregate_combined_event_data).with(real_events, ideal_events)
+        expect(described_class).to have_received(:where).with(user: user)
+        expect(life_events).to have_received(:where).with(event_type: 0)
+        expect(life_events).to have_received(:where).with(event_type: 1)
+        expect(described_class).to have_received(:aggregate_event_data).with(real_events)
+        expect(described_class).to have_received(:aggregate_event_data).with(real_events + ideal_events)
 
-      # 戻り値
-      expect(result).to eq({ real_event_data: real_event_data, ideal_event_data: ideal_event_data })
+        expect(result).to eq({ real_event_data: real_event_data, ideal_event_data: ideal_event_data })
+      end
     end
-  end
 
-  describe ".extract_yearly_amounts" do
-    it "イベントごとに支払期間分の金額を正しく算出する" do
-      events = [ real_event1, real_event2 ]
-      result = described_class.send(:extract_yearly_amounts, events)
+    context "ideal_events が存在しない場合" do
+      before do
+        allow(ideal_events).to receive(:present?).and_return(false)
+      end
 
-      expect(result).to contain_exactly({ date: 2025, amount: -10 }, { date: 2026, amount: -10 }, { date: 2026, amount: -20 })
+      it "内部メソッドが正しく呼ばれ、理想データはnilを返す" do
+        result = described_class.generate_life_event_data_for(user)
+
+        expect(described_class).to have_received(:where).with(user: user)
+        expect(life_events).to have_received(:where).with(event_type: 0)
+        expect(life_events).to have_received(:where).with(event_type: 1)
+        expect(described_class).to have_received(:aggregate_event_data).with(real_events)
+        expect(described_class).not_to have_received(:aggregate_event_data).with(real_events + ideal_events)
+
+        expect(result).to eq({ real_event_data: real_event_data, ideal_event_data: nil })
+      end
     end
   end
 
@@ -139,42 +150,37 @@ RSpec.describe LifeEvent, type: :model do
   end
 
   describe ".aggregate_event_data" do
-    it "イベントのデータを正しく集計する" do
+    let(:real_event1) { double("real_event1", event_date: Date.new(2025, 1, 1), payment_period: 1, amount: 10) }
+    let(:real_event2) { double("real_event2", event_date: Date.new(2026, 1, 1), payment_period: 1, amount: 30) }
+
+    it "イベントのデータを集計する" do
       events = [ real_event1, real_event2 ]
+      year_amounts = [ { date: 2025, amount: -10 }, { date: 2026, amount: -30 } ]
+
+      allow(described_class).to receive(:extract_yearly_amounts).with(events).and_return(year_amounts)
+      allow(described_class).to receive(:aggregate_by_year).with(year_amounts).and_return([
+        { date: 2025, amount: -10 }, { date: 2026, amount: -30 }
+      ])
+
       result = described_class.send(:aggregate_event_data, events)
 
       expect(result).to contain_exactly({ date: 2025, amount: -10 }, { date: 2026, amount: -30 })
     end
   end
 
-  describe ".aggregate_combined_event_data" do
-    let(:real_event1) { { date: 2025, amount: -10 } }
-    let(:real_event2) { { date: 2026, amount: -30 } }
-    let(:ideal_event1) { { date: 2025, amount: -50 } }
+  describe ".extract_yearly_amounts" do
+    let(:real_event1) { double("real_event1", event_date: Date.new(2025, 1, 1), payment_period: 2, amount: 10) }
+    let(:real_event2) { double("real_event2", event_date: Date.new(2026, 1, 1), payment_period: 1, amount: 20) }
 
-    before do
-      allow(described_class).to receive(:aggregate_event_data).with([ real_event1, real_event2 ])
-      allow(described_class).to receive(:aggregate_event_data).with([ ideal_event1 ])
-      allow(described_class).to receive(:merge_yearly_amounts)
-    end
+    it "イベントごとに支払期間分の金額を正しく算出する" do
+      events = [ real_event1, real_event2 ]
+      result = described_class.send(:extract_yearly_amounts, events)
 
-    it "内部メソッドが正しく呼ばれる" do
-      described_class.aggregate_combined_event_data([ real_event1, real_event2 ], [ ideal_event1 ])
-
-      expect(described_class).to have_received(:aggregate_event_data).with([ real_event1, real_event2 ])
-      expect(described_class).to have_received(:aggregate_event_data).with([ ideal_event1 ])
-      expect(described_class).to have_received(:merge_yearly_amounts)
-    end
-  end
-
-  describe ".merge_yearly_amounts" do
-    it "現実と理想のイベントデータを統合する" do
-      real_data = [ { date: 2025, amount: -10 }, { date: 2026, amount: -30 } ]
-      ideal_data = [ { date: 2025, amount: -50 }, { date: 2027, amount: -20 } ]
-
-      result = described_class.send(:merge_yearly_amounts, real_data, ideal_data)
-
-      expect(result).to contain_exactly({ date: 2025, amount: -60 }, { date: 2026, amount: -30 }, { date: 2027, amount: -20 })
+      expect(result).to contain_exactly(
+        { date: 2025, amount: -10 }, # real_event1 の 1年目
+        { date: 2026, amount: -10 }, # real_event1 の 2年目
+        { date: 2026, amount: -20 }  # real_event2 の 1年目
+      )
     end
   end
 end

--- a/spec/models/simulation_spec.rb
+++ b/spec/models/simulation_spec.rb
@@ -19,38 +19,51 @@ RSpec.describe Simulation, type: :model do
   end
 
   describe 'クラスメソッドテスト' do
-    let(:life_event_data) { { "date"=>2000, "amount"=>100 } }
+    describe ".calculate_scenario_data222" do
+      let(:life_event_data) { [ { "date" => 2000, "amount" => 100 } ] }
 
-    describe '.calculate_scenario_data' do
       before do
-        allow(simulation).to receive(:merged_income_expense_event).with(life_event_data).and_return({ "date"=>2000, "amount"=>100 })
+        allow(simulation).to receive(:merged_income_expense_event).with(life_event_data).and_return([ { "date" => 2000, "amount" => 100 } ])
         allow(simulation).to receive(:get_total_income).and_return(2000)
-
-        # life_event_dataにreal_event_data入っていない場合を想定
-        simulation.expense_data = [ { "date"=>2000, "amount"=>100 } ]
-        simulation.real_event_data = [ { "date"=>2000, "amount"=>100 } ]
-        valid_datasets = [ simulation.expense_data, life_event_data, simulation.real_event_data ]
-        allow(simulation).to receive(:get_total_expense).with(*valid_datasets).and_return(-1000)
-
         allow(simulation).to receive(:get_monthly_expense).and_return(20)
-        allow(simulation).to receive(:calculate_shortage).with(1000).and_return(100)
         allow(described_class).to receive(:calculate_and_save_lifespan_data).with(simulation)
       end
 
-      it 'シナリオデータを計算する各処理が正しく呼ばれる' do
-        result = described_class.calculate_scenario_data(simulation, life_event_data)
+      context "total_balance が正の場合" do
+        before do
+          allow(simulation).to receive(:get_total_expense).with(simulation.expense_data, life_event_data).and_return(-1000)
+        end
 
-        expect(result[:balance_scenario]).to eq({ "date"=>2000, "amount"=>100 })
-        expect(result[:total_income]).to eq(2000)
-        expect(result[:total_expense]).to eq(-1000)
-        expect(result[:total_balance]).to eq(1000)  # 2000 + (-1000)
-        expect(result[:withdrawal]).to eq(50)  # 1000 / 20
-        expect(result[:shortage]).to eq(0)  # total_balance > 0 のため
+        it "シナリオデータを正しく計算し、資産寿命データを計算・保存する" do
+          result = described_class.calculate_scenario_data(simulation, life_event_data)
+
+          expect(result[:balance_scenario]).to eq([ { "date" => 2000, "amount" => 100 } ])
+          expect(result[:total_income]).to eq(2000)
+          expect(result[:total_expense]).to eq(-1000)
+          expect(result[:total_balance]).to eq(1000)
+          expect(result[:withdrawal]).to eq(50)
+          expect(result[:shortage]).to eq(0)
+          expect(described_class).to have_received(:calculate_and_save_lifespan_data).with(simulation)
+        end
       end
 
-      it '資産寿命データの計算と保存をする処理が呼ばれる' do
-        expect(described_class).to receive(:calculate_and_save_lifespan_data).with(simulation)
-        described_class.calculate_scenario_data(simulation, life_event_data)
+      context "total_balance が負の場合" do
+        before do
+          allow(simulation).to receive(:get_total_expense).with(simulation.expense_data, life_event_data).and_return(-3000)
+          allow(simulation).to receive(:calculate_shortage).with(-1000).and_return(100)
+        end
+
+        it "シナリオデータを正しく計算し、資産寿命データを計算・保存する" do
+          result = described_class.calculate_scenario_data(simulation, life_event_data)
+
+          expect(result[:balance_scenario]).to eq([ { "date" => 2000, "amount" => 100 } ])
+          expect(result[:total_income]).to eq(2000)
+          expect(result[:total_expense]).to eq(-3000)
+          expect(result[:total_balance]).to eq(-1000)
+          expect(result[:withdrawal]).to eq(0)
+          expect(result[:shortage]).to eq(100)
+          expect(described_class).to have_received(:calculate_and_save_lifespan_data).with(simulation)
+        end
       end
     end
 


### PR DESCRIPTION
### 1. 下記問題に対するロジックとテストの修正
* 問題
life_eventモデルで、「理想と現実イベントの両方を含むideal_event_data」を作成しているにも関わらず、simulationモデルでideal_event_dataに現実イベントの値の再追加をしていた。これにより、シミュレーション結果が不適切な値になっていた。

* 改善
現実イベント値の再追加の原因である、simulationモデル内datasetsの定義を修正し、各life_event_dataずつ処理する仕様に変更。


### 2. LifeEventモデルのリファクタリング
- 冗長箇所の改善後、下記メソッドを削除。
　* aggregate_combined_event_data
　* def self.merge_yearly_amounts

### 3. 上記変更・リファクタリングに伴うテスト修正