### PR TITLE
refactor: private method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
   validates :password, presence: true, format: { with: /\A(?=.*[a-z])(?=.*\d)[a-z\d]{8,}\z/ }, if: :password_required?
   validates :password_confirmation, presence: true, if: -> { password.present? }
 
-  after_create :create_simulation_and_scenario_models
+  after_create :initialize_simulation_and_scenarios
 
   def calculate_user_age
     current_date = Date.today
@@ -30,13 +30,9 @@ class User < ApplicationRecord
     age
   end
 
-  # snsログイン（ユーザーを検索or作成）
   def self.find_or_create_for_oauth(auth)
     sns = SnsCredential.find_or_create_by(uid: auth.uid, provider: auth.provider)
-    user = sns.user || User.find_by(email: auth.info.email)
-    if user.nil?
-      user = self.create_user_from_auth(auth)
-    end
+    user = sns.user || User.find_by(email: auth.info.email) || self.create_user_from_auth(auth)
     self.associate_sns_with_user(sns, user)
   end
 
@@ -45,38 +41,21 @@ class User < ApplicationRecord
   # sns使用ユーザー：登録も更新も無効
   # 一般ユーザー：登録は有効、更新は入力があれば有効、なければ無効
   def password_required?
-    if sns_credentials.exists?
-      false
-    elsif new_record?
-      true
-    else
-      password.present? || password_confirmation.present?
-    end
+    return false if sns_credentials.exists?
+    new_record? || password.present? || password_confirmation.present?
   end
 
   # sns使用ユーザー：登録は無効、更新は有効
   # 一般ユーザー：登録も更新も有効
   def date_of_birth_required?
-    return true if sns_credentials.empty?
-
-    if sns_credentials.exists? && new_record?
-      false
-    else
-      true
-    end
+    sns_credentials.empty? || !new_record?
   end
 
-  # 空のsimulation, scenario作成
-  def create_simulation_and_scenario_models
-    Simulation.create(user: self)
-
-    scenario_types = [ "現実", "理想" ]
-    scenario_types.each do |type|
-      Scenario.create(user: self, simulation: simulation, scenario_type: type)
-    end
+  def initialize_simulation_and_scenarios
+    simulation = create_simulation!
+    simulation.scenarios.create!([ { user: self, scenario_type: "現実" }, { user: self, scenario_type: "理想" } ])
   end
 
-  # snsを元にユーザー作成
   def self.create_user_from_auth(auth)
     user = User.new(
       email: auth.info.email,
@@ -89,7 +68,6 @@ class User < ApplicationRecord
     user
   end
 
-  # snsとuserの関連付け
   def self.associate_sns_with_user(sns, user)
     sns.user = user
     sns.save!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { build(:user) }
-
   describe 'アソシエーションテスト' do
     it { is_expected.to have_many(:incomes).dependent(:destroy) }
     it { is_expected.to have_many(:expenses).dependent(:destroy) }
@@ -16,6 +14,8 @@ RSpec.describe User, type: :model do
   end
 
   describe 'バリデーションテスト' do
+    let(:user) { build(:user) }
+
     context '必須項目の確認' do
       it 'ユーザー名がnilの場合無効' do
         user.name = nil
@@ -48,21 +48,21 @@ RSpec.describe User, type: :model do
       end
     end
 
-    it 'パスワードと確認用パスワードが一致しない場合、無効であること' do
+    it 'パスワードと確認用パスワードが不一致の場合は無効' do
       user.password_confirmation = "different_password"
       expect(user).not_to be_valid
       expect(user.errors[:password_confirmation]).to include("パスワードが一致していません。")
     end
 
     context 'パスワードの長さ' do
-      it '8字未満は無効であること' do
+      it '8字未満は無効' do
         user.password = 'short'
         user.password_confirmation = 'short'
         expect(user).not_to be_valid
         expect(user.errors[:password]).to include("パスワードは8字以上30字以下としてください。")
       end
 
-      it '30字を超える場合は無効であること' do
+      it '30字を超える場合は無効' do
         user.password = 'a' * 31
         user.password_confirmation = 'a' * 31
         expect(user).not_to be_valid
@@ -71,14 +71,14 @@ RSpec.describe User, type: :model do
     end
 
     context 'パスワードの形式（英数字）' do
-      it '文字のみのパスワードは無効であること' do
+      it '文字のみのパスワードは無効' do
         user.password = 'onlyletters'
         user.password_confirmation = 'onlyletters'
         expect(user).not_to be_valid
         expect(user.errors[:password]).to include("パスワードは英数字である必要があります。")
       end
 
-      it '数字のみのパスワードは無効であること' do
+      it '数字のみのパスワードは無効' do
         user.password = '1234567890'
         user.password_confirmation = '1234567890'
         expect(user).not_to be_valid
@@ -88,36 +88,58 @@ RSpec.describe User, type: :model do
   end
 
   describe 'カスタムバリデーションテスト' do
+    let(:user) { build(:user) }
+
     describe '#password_required?' do
-      it 'SNSユーザーは、パスワードは不要であること' do
+      it 'SNSユーザーは、パスワードが不要' do
         sns_mock = double('SnsCredential', exists?: true)
         allow(user).to receive(:sns_credentials).and_return(sns_mock)
         expect(user.send(:password_required?)).to be false
       end
 
-      it '一般ユーザーは、パスワードが必須であること' do
+      it '新規一般ユーザーは、パスワードが必須' do
         sns_mock = double('SnsCredential', exists?: false)
         allow(user).to receive(:sns_credentials).and_return(sns_mock)
+        allow(user).to receive(:new_record?).and_return(true)
+        expect(user.send(:password_required?)).to be true
+      end
+
+      it '既存一般ユーザーは、パスワードが不要（パスワードが未入力の場合）' do
+        sns_mock = double('SnsCredential', exists?: false)
+        allow(user).to receive(:sns_credentials).and_return(sns_mock)
+        allow(user).to receive(:new_record?).and_return(false)
+        allow(user).to receive(:password).and_return(nil)
+        allow(user).to receive(:password_confirmation).and_return(nil)
+        expect(user.send(:password_required?)).to be false
+      end
+
+      it '既存一般ユーザーは、パスワードが必須（パスワードが入力されている場合）' do
+        sns_mock = double('SnsCredential', exists?: false)
+        allow(user).to receive(:sns_credentials).and_return(sns_mock)
+        allow(user).to receive(:new_record?).and_return(false)
+        allow(user).to receive(:password).and_return('changepassword')
+        allow(user).to receive(:password_confirmation).and_return('changepassword')
         expect(user.send(:password_required?)).to be true
       end
     end
 
     describe '#date_of_birth_required?' do
-      it 'SNSユーザーは、生年月日は不要であること' do
-        sns_mock = double('SnsCredential', empty?: false, exists?: true)
+      it 'SNSユーザーは、新規レコードの場合は生年月日は不要' do
+        sns_mock = double('SnsCredential', empty?: false)
         allow(user).to receive(:sns_credentials).and_return(sns_mock)
+        allow(user).to receive(:new_record?).and_return(true)
         expect(user.send(:date_of_birth_required?)).to be false
       end
 
-      it 'SNSユーザーが既存レコードのとき、生年月日は必須であること' do
-        sns_mock = double('SnsCredential', empty?: false, exists?: true)
+      it 'SNSユーザーは、既存レコードのときは生年月日は必須' do
+        sns_mock = double('SnsCredential', empty?: false)
         allow(user).to receive(:sns_credentials).and_return(sns_mock)
         allow(user).to receive(:new_record?).and_return(false)
         expect(user.send(:date_of_birth_required?)).to be true
       end
 
-      it '一般ユーザーは、生年月日が必須であること' do
-        sns_mock = double('SnsCredential', empty?: true, exists?: false)
+      it '一般ユーザーは、生年月日が必須' do
+        sns_mock = double('SnsCredential', empty?: true)
         allow(user).to receive(:sns_credentials).and_return(sns_mock)
         expect(user.send(:date_of_birth_required?)).to be true
       end


### PR DESCRIPTION
#### privateメソッドのリファクタリング
- カスタムバリデーションの条件分岐をシンプルな形に修正。
- simulation, scenariosテーブル作成（ユーザー登録時）処理をループから配列を使った一括保存に変更。
- 上記に伴うテストコードの修正。