### PR TITLE
refactor: extract redirect & messages to methods

### DIFF
--- a/app/controllers/incomes_controller.rb
+++ b/app/controllers/incomes_controller.rb
@@ -27,14 +27,6 @@ class IncomesController < ApplicationController
     end
   end
 
-  def update_simulation_data
-    if current_user.simulation.update_income_data!(current_user)
-      redirect_to expenses_path, notice: t("message.simulation.update.success")
-    else
-      redirect_to incomes_path, alert: t("message.simulation.update.failure")
-    end
-  end
-
   private
 
   def set_incomes

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -1,50 +1,61 @@
 class SimulationsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_simulation
 
   def update_income_data
-    return redirect_to incomes_path, alert: t("message.simulation.update.failure") unless current_user.simulation
-
     income_data = Income.generate_income_data_for(current_user)
-    if current_user.simulation.update!(income_data: income_data)
-      redirect_to expenses_path, notice: t("message.simulation.update.success")
+
+    if @simulation.update(income_data: income_data)
+      update_success(expenses_path)
     else
-      redirect_to incomes_path, alert: t("message.simulation.update.failure")
+      update_failure(incomes_path)
     end
   end
 
   def update_expense_data
-    return redirect_to expenses_path, alert: t("message.simulation.update.failure") unless current_user.simulation
-
     expense_data = Expense.generate_expense_data_for(current_user)
-    if current_user.simulation.update!(expense_data: expense_data)
-      redirect_to user_assets_path, notice: t("message.simulation.update.success")
+
+    if @simulation.update(expense_data: expense_data)
+      update_success(user_assets_path)
     else
-      redirect_to expenses_path, alert: t("message.simulation.update.failure")
+      update_failure(expenses_path)
     end
   end
 
   def update_user_asset_data
-    return redirect_to user_assets_path, alert: t("message.simulation.update.failure") unless current_user.simulation
-
     user_asset_data = UserAsset.generate_user_asset_data_for(current_user)
-    if current_user.simulation.update!(user_asset_data: user_asset_data)
-      redirect_to new_life_event_path, notice: t("message.simulation.update.success")
+
+    if @simulation.update(user_asset_data: user_asset_data)
+      update_success(new_life_event_path)
     else
-      redirect_to user_assets_path, alert: t("message.simulation.update.failure")
+      update_failure(user_assets_path)
     end
   end
 
   def update_life_event_data
-    return redirect_to new_life_event_path, alert: t("message.simulation.update.failure") unless current_user.simulation
-
     life_event_data = LifeEvent.generate_life_event_data_for(current_user)
-    if current_user.simulation.update!(
+
+    if @simulation.update(
       real_event_data: life_event_data[:real_event_data].presence,
       ideal_event_data: life_event_data[:ideal_event_data].presence
     )
-      redirect_to scenarios_path, notice: t("message.simulation.update.success")
+      update_success(scenarios_path)
     else
-      redirect_to new_life_event_path, alert: t("message.simulation.update.failure")
+      update_failure(new_life_event_path)
     end
+  end
+
+  private
+
+  def set_simulation
+    @simulation = current_user.simulation
+  end
+
+  def update_success(path)
+    redirect_to path, notice: t("message.simulation.update.success")
+  end
+
+  def update_failure(path)
+    redirect_to path, alert: t("message.simulation.update.failure")
   end
 end

--- a/spec/requests/simulations_spec.rb
+++ b/spec/requests/simulations_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Simulations", type: :request do
     context '失敗した場合' do
       before do
         allow(Income).to receive(:generate_income_data_for).and_return(income_data)
-        allow_any_instance_of(Simulation).to receive(:update!).and_return(false)
+        allow_any_instance_of(Simulation).to receive(:update).and_return(false)
         post update_income_data_simulation_path
       end
 
@@ -44,7 +44,7 @@ RSpec.describe "Simulations", type: :request do
     context '成功した場合' do
       before do
         allow(Expense).to receive(:generate_expense_data_for).and_return(expense_data)
-        allow_any_instance_of(Simulation).to receive(:update!).and_return(true)
+        allow_any_instance_of(Simulation).to receive(:update).and_return(true)
         post update_expense_data_simulation_path
       end
 
@@ -57,7 +57,7 @@ RSpec.describe "Simulations", type: :request do
     context '失敗した場合' do
       before do
         allow(Expense).to receive(:generate_expense_data_for).and_return(expense_data)
-        allow_any_instance_of(Simulation).to receive(:update!).and_return(false)
+        allow_any_instance_of(Simulation).to receive(:update).and_return(false)
         post update_expense_data_simulation_path
       end
 
@@ -87,7 +87,7 @@ RSpec.describe "Simulations", type: :request do
     context '失敗した場合' do
       before do
         allow(UserAsset).to receive(:generate_user_asset_data_for).and_return(user_asset_data)
-        allow_any_instance_of(Simulation).to receive(:update!).and_return(false)
+        allow_any_instance_of(Simulation).to receive(:update).and_return(false)
         post update_user_asset_data_simulation_path
       end
 
@@ -117,7 +117,7 @@ RSpec.describe "Simulations", type: :request do
     context '失敗した場合' do
       before do
         allow(LifeEvent).to receive(:generate_life_event_data_for).and_return(life_event_data)
-        allow_any_instance_of(Simulation).to receive(:update!).and_return(false)
+        allow_any_instance_of(Simulation).to receive(:update).and_return(false)
         post update_life_event_data_simulation_path
       end
 


### PR DESCRIPTION
#### 1. 不要な記述削除
- incomes_controller内のupdate_simulation_dataメソッド（前回の修正で削除し忘れていた）
  現状、simulation_controller内で同じ処理を担当している。

#### 2. simulations_controller内のデータ更新使用修正
- update!を使用して更新をしていたが、条件分岐（if）でのハンドリングをしているため「update」に変更。
- 上記に伴いテストコードを修正。

#### 3. simulations_controller内のリダイレクト・メッセージ定義をメソッド化
- 可読性と冗長改善を考慮し、update_successメソッド、update_failureメソッドを設置（引数にリダイレクト先を設定する仕様）