### PR TITLE
refactor: partialize in application.html.erb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "ruby-openai", "~> 7.4"
 
 group :development, :test do
   gem "debug", "~> 1.9", platforms: %i[ mri windows ], require: "debug/prelude"
-  gem "brakeman", "~> 7.0.1", require: false  # Static analysis for security vulnerabilities
+  gem "brakeman", "~> 7.0", require: false  # Static analysis for security vulnerabilities
   gem "rubocop-rails-omakase", "~> 1.0", require: false  # Omakase Ruby styling
 
   # rubocop関連

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.1)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -421,7 +421,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (~> 1.18)
-  brakeman (~> 7.0.1)
+  brakeman (~> 7.0)
   capybara (~> 3.40)
   chartkick (~> 5.1)
   cssbundling-rails (~> 1.4)

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,3 +1,4 @@
+<!-- google_analytics -->
 <% if Rails.env.production? %>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-K2ESRMDEY1"></script>

--- a/app/views/layouts/_external_resources.html.erb
+++ b/app/views/layouts/_external_resources.html.erb
@@ -1,4 +1,0 @@
-<!-- bootstrapのCSS -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
-<!-- FontAwesomeのJSキット -->
-<script src="https://kit.fontawesome.com/8096f95eec.js" crossorigin="anonymous"></script>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,17 @@
+<footer class="py-4">
+  <div class="container d-flex flex-column flex-md-row justify-content-between align-items-center">
+    <div>
+      <%=
+        link_to 'お問い合わせ', 
+        "https://docs.google.com/forms/d/e/1FAIpQLSfs5-SIS7h3jQtT4F3ulKjLrdgpX-EJjNNPqpkwhuBQ6s41dA/viewform?usp=sf_link", 
+        class: "btn btn-link px-2", target: "_blank", rel: "noopener", data: { turbo: true }
+      %>
+      <%= link_to 'プライバシーポリシー', static_pages_privacy_path, class: "btn btn-link px-2", data: { turbo: true } %>
+      <%= link_to '利用規約', static_pages_terms_path, class: "btn btn-link px-2", data: { turbo: true } %>
+    </div>
+
+    <div class="text-center mt-md-0">
+      &copy; <%= Time.now.year %> Scenapla. All rights reserved.
+    </div>
+  </div>
+</footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,20 @@
+<header>
+  <nav class="navbar navbar-dark">
+    <div class="container-fluid">
+      <%= link_to 'Scenapla', user_signed_in? ? dashboard_index_path : root_path, class: 'navbar-brand', data: { turbo: false } %>
+      <% if user_signed_in? %>
+        <div>
+          <span class="sp-btn-username d-none d-md-inline"><%= "#{current_user.name}さん" %></span>
+
+          <!-- ハンバーガー（オフキャンバストリガー） -->
+          <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-controls="offcanvasNavbar">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+        </div>
+        <%= render 'layouts/offcanvas' %>
+      <% else %>
+        <%= link_to 'ログイン', new_user_session_path, class: 'btn btn-outline-light btn-login', data: { turbo: true } %>
+      <% end %>
+    </div>
+  </nav>
+</header>

--- a/app/views/layouts/_nav_tabs.html.erb
+++ b/app/views/layouts/_nav_tabs.html.erb
@@ -1,20 +1,37 @@
 <ul class="nav nav-tabs justify-content-center bg-light sticky-top">
   <li class="nav-item">
-    <%= link_to dashboard_index_path, class: "nav-link text-muted #{'active fw-bold' if current_page?(dashboard_index_path)}", data: { turbo: true } do %>
+    <%= 
+      link_to dashboard_index_path,
+      class: "nav-link text-muted #{'active fw-bold' if current_page?(dashboard_index_path)}",
+      data: { turbo: true } do
+    %>
       <i class="fa-solid fa-house"></i>
       <span class="d-none d-sm-inline">ダッシュボード</span>
     <% end %>
   </li>
 
   <li class="nav-item">
-    <%= link_to news_index_path, class: "nav-link text-muted #{'active fw-bold' if current_page?(news_index_path)}", data: { turbo: true } do %>
+    <%= 
+      link_to news_index_path,
+      class: "nav-link text-muted #{'active fw-bold' if current_page?(news_index_path)}",
+      data: { turbo: true } do
+    %>
       <i class="fa-regular fa-newspaper"></i>
       <span class="d-none d-sm-inline">ニュース</span>
     <% end %>
   </li>
 
   <li class="nav-item dropdown">
-    <%= link_to '#', class: "nav-link dropdown-toggle text-muted #{'active fw-bold' if [incomes_path, expenses_path, user_assets_path, new_life_event_path].include?(request.fullpath)}", id: 'navbarDropdown', data: { bs_toggle: 'dropdown', turbo: true }, aria: { expanded: 'false' } do %>
+    <%=
+      link_to '#',
+      class: "nav-link dropdown-toggle text-muted #{'active fw-bold' if [incomes_path,
+                                                                         expenses_path,
+                                                                         user_assets_path,
+                                                                         new_life_event_path].include?(request.fullpath)}",
+      id: 'navbarDropdown',
+      data: { bs_toggle: 'dropdown', turbo: true },
+      aria: { expanded: 'false' } do
+    %>
       <i class="fa-regular fa-keyboard"></i>  
       <span class="d-none d-sm-inline">シミュレーション</span>
     <% end %>
@@ -28,14 +45,22 @@
   </li>
 
   <li class="nav-item">
-    <%= link_to scenarios_path, class: "nav-link text-muted #{'active fw-bold' if current_page?(scenarios_path)}", data: { turbo: true } do %>
+    <%=
+      link_to scenarios_path,
+      class: "nav-link text-muted #{'active fw-bold' if current_page?(scenarios_path)}",
+      data: { turbo: true } do
+    %>
       <i class="fa-solid fa-chart-line"></i>
       <span class="d-none d-sm-inline">シナリオ</span>
     <% end %>
   </li>
 
   <li class="nav-item">
-    <%= link_to life_events_path, class: "nav-link text-muted #{'active fw-bold' if current_page?(life_events_path)}", data: { turbo: true } do %>
+    <%=
+      link_to life_events_path,
+      class: "nav-link text-muted #{'active fw-bold' if current_page?(life_events_path)}",
+      data: { turbo: true } do
+    %>
       <i class="fa-regular fa-map"></i>
       <span class="d-none d-sm-inline">ライフプラン</span>
     <% end %>

--- a/app/views/layouts/_offcanvas.html.erb
+++ b/app/views/layouts/_offcanvas.html.erb
@@ -1,4 +1,3 @@
-<!-- offcanvasメニュー -->
 <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
   <div class="offcanvas-header">
     <h5 class="offcanvas-title" id="offcanvasNavbarLabel"><%= "#{current_user.name}さん" %></h5>
@@ -6,9 +5,9 @@
   </div>
 
   <div class="offcanvas-body">
-    <!-- ページボタン -->
     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
       <% if current_user.date_of_birth.nil? %>
+        
         <!-- 生年月日が未登録のユーザーへの表示 -->
         <li class="nav-item">
           <%= link_to "アカウント情報", user_path(current_user), class: 'nav-link' %>
@@ -18,6 +17,7 @@
           <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: 'nav-link' %>
         </li>
       <% else %>
+        
         <!-- 生年月日が登録済のユーザーへの表示 -->
         <li class="nav-item">
           <%= link_to 'ダッシュボード', dashboard_index_path, class: 'nav-link', data: { turbo: true } %>

--- a/app/views/layouts/_ogp.html.erb
+++ b/app/views/layouts/_ogp.html.erb
@@ -1,4 +1,3 @@
-<!-- OGP -->
 <meta property="og:title" content="Scenapla">
 <meta property="og:description" content="このアプリは、経済とライフイベントの計画をサポートするツールです。">
 <meta property="og:type" content="website">

--- a/app/views/layouts/_resources.html.erb
+++ b/app/views/layouts/_resources.html.erb
@@ -1,0 +1,7 @@
+<!-- external_resources -->
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">  <!-- bootstrapのCSS -->
+<script src="https://kit.fontawesome.com/8096f95eec.js" crossorigin="anonymous"></script>             <!-- FontAwesomeのJSキット -->
+
+<!-- internal_resources -->
+<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+<%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,45 +11,16 @@
     <%= csp_meta_tag %>
 
     <%= render "layouts/ogp" %>
-    <%= yield :head %>
     <%= render "layouts/analytics" %>
-
-    <%= render "layouts/external_resources" %>
+    <%= render "layouts/resources" %>
     <%= render "layouts/icons" %>
-
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
   <body>
-    <header>
-      <nav class="navbar navbar-dark">
-        <div class="container-fluid">
-          <%= link_to 'Scenapla', user_signed_in? ? dashboard_index_path : root_path, class: 'navbar-brand', data: { turbo: false } %>
-
-          <% if user_signed_in? %>
-            <div>
-              <span class="sp-btn-username d-none d-md-inline"><%= "#{current_user.name}さん" %></span>
-
-              <!-- ハンバーガー（オフキャンバストリガー） -->
-              <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar"
-                aria-controls="offcanvasNavbar">
-                <span class="navbar-toggler-icon"></span>
-              </button>
-            </div>
-
-            <!-- オフキャンバス -->
-            <%= render 'layouts/offcanvas' %>
-          <% else %>
-            <%= link_to 'ログイン', new_user_session_path, class: 'btn btn-outline-light btn-login', data: { turbo: true } %>
-          <% end %>
-        </div>
-      </nav>
-    </header>
+    <%= render 'layouts/header' %>
 
     <main>
       <% if user_signed_in? && current_user.date_of_birth.present? %>
-        <!-- ナビゲーションタブ -->
         <%= render 'layouts/nav_tabs' %>
       <% end %>
 
@@ -61,20 +32,6 @@
       <%= yield %>
     </main>
 
-    <footer class="py-4">
-      <div class="container d-flex flex-column flex-md-row justify-content-between align-items-center">
-        <div>
-          <%= link_to 'お問い合わせ', 
-                "https://docs.google.com/forms/d/e/1FAIpQLSfs5-SIS7h3jQtT4F3ulKjLrdgpX-EJjNNPqpkwhuBQ6s41dA/viewform?usp=sf_link", 
-                class: "btn btn-link px-2", target: "_blank", rel: "noopener", data: { turbo: true } %>
-          <%= link_to 'プライバシーポリシー', static_pages_privacy_path, class: "btn btn-link px-2", data: { turbo: true } %>
-          <%= link_to '利用規約', static_pages_terms_path, class: "btn btn-link px-2", data: { turbo: true } %>
-        </div>
-
-        <div class="text-center mt-md-0">
-          &copy; <%= Time.now.year %> My Website. All rights reserved.
-        </div>
-      </div>
-    </footer>
+    <%= render 'layouts/footer' %>
   </body>
 </html>


### PR DESCRIPTION
#### 1. application.html.erbの整理
- 内部のパーシャル化
- リソースについて、internal（application.html.erb内）とexternal（パーシャル）で分けていたが、_resources.html.erbとして、1つのパーシャルにまとめた。
  今後、ページによってリソースを読み込む可動化の判断が増える場合は、yield :headなどを使用する。