### PR TITLE
feat: add display for remaining ai_advice generation count

### DIFF
--- a/app/controllers/life_events_controller.rb
+++ b/app/controllers/life_events_controller.rb
@@ -7,6 +7,7 @@ class LifeEventsController < ApplicationController
     @grouped_life_events = group_life_events
     @memos = group_memos
     @advice = get_advice
+    @remaining_advice_count = get_advice_count
   end
 
   def new
@@ -68,5 +69,12 @@ class LifeEventsController < ApplicationController
   def get_advice
     advice_record = current_user.ai_advices.last
     advice_record.present? ? advice_record.content : nil
+  end
+
+  def get_advice_count
+    start_of_month = Time.zone.now.beginning_of_month
+    monthly_advice_total = current_user.ai_advices.where("created_at >= ?", start_of_month).count
+    result = monthly_advice_total - 3
+    result < 0 ? result.abs : result
   end
 end

--- a/app/views/openai_advices/_show.html.erb
+++ b/app/views/openai_advices/_show.html.erb
@@ -2,6 +2,7 @@
   <div class="card-header d-flex align-items-center">
     <h4 class="mt-2">AI からのアドバイス</h4>
     <%= button_to '生成する', generate_advice_openai_advice_path, method: :post, class: "btn btn-outline-primary btn-sm ms-3" %>
+    <p class="mt-3 ms-auto text-muted">今月の生成可能回数 残り <%= @remaining_advice_count %> 回</p>
   </div>
   <div class="card-body">
     <% if @advice.nil? %>


### PR DESCRIPTION
# 概要
AIアドバイスの「生成可能回数」の表示機能追加

# 行ったこと
1. life_events_controller.rbの編集
  - indexアクション内に「残りアドバイス回数」の変数を定義
  - private内に「残りアドバイス回数」を取得するメソッドを定義

2. openai_advices/_show.html.erbの編集
  - 残りのアドバイス回数を格納した変数を表示（「今月の生成可能回数 残り 〇回」）