### PR TITLE
fix: income_form & income_reqest_spec

### DIFF
--- a/app/views/incomes/_income_form.html.erb
+++ b/app/views/incomes/_income_form.html.erb
@@ -1,7 +1,4 @@
-<%= form_with model: income, url: income.persisted? ? income_path(income) : incomes_path,
-                             method: income.persisted? ? :patch : :post,
-                             local: true do |f|
-%>
+<%= form_with model: income, local: true do |f| %>
 	<div class="row d-flex justify-content-center">
     <div class="col-md-4 col-lg-2 col-xl-2">
       <%= f.label :person_type, '対象者', class: 'form-label' %>

--- a/spec/requests/incomes_spec.rb
+++ b/spec/requests/incomes_spec.rb
@@ -16,18 +16,6 @@ RSpec.describe "Incomes", type: :request do
     end
   end
 
-  describe "GET /edit" do
-    it "編集フォームを表示し200を返す" do
-      get edit_income_path(income)
-      expect(response).to have_http_status(:success)
-    end
-
-    it "存在しないincomeなら404を返す" do
-      get edit_income_path(-1) # 存在しないID
-      expect(response).to have_http_status(:not_found) # 404
-    end
-  end
-
   describe "POST /create" do
     let(:valid_params) do
       { income: attributes_for(:income) }
@@ -46,6 +34,22 @@ RSpec.describe "Incomes", type: :request do
     end
   end
 
+  describe "GET /edit" do
+    context "データが存在する場合" do
+      it "編集フォームを表示し、200を返す" do
+        get edit_income_path(income)
+        expect(response).to have_http_status(:success) # 200
+      end
+    end
+
+    context "データが存在しない場合" do
+      it "404を返す" do
+        get edit_income_path(-1) # 存在しないID
+        expect(response).to have_http_status(:not_found) # 404
+      end
+    end
+  end
+
   describe "PATCH /update" do
     let(:update_params) do
       {
@@ -59,34 +63,41 @@ RSpec.describe "Incomes", type: :request do
       }
     end
 
-    it "更新成功時は302を返す" do
-      patch income_path(income), params: update_params
-      expect(response).to have_http_status(:found)
+    context "有効なパラメータの場合" do
+      it "更新し、302を返す" do
+        patch income_path(income), params: update_params
+        expect(response).to have_http_status(:found)
 
-      income.reload
-      expect(income.monthly_income).to eq 50.0
-      expect(income.yearly_bonus).to eq 100.0
-      expect(income.person_type).to eq "本人"
-      expect(income.retirement_date).to eq Date.new(2035)
-      expect(income.retirement_pay).to eq 300.0
+        income.reload
+        expect(income.monthly_income).to eq 50.0
+        expect(income.yearly_bonus).to eq 100.0
+        expect(income.person_type).to eq "本人"
+        expect(income.retirement_date).to eq Date.new(2035)
+        expect(income.retirement_pay).to eq 300.0
+      end
     end
 
-    it "更新失敗時は422を返す" do
-      allow_any_instance_of(Income).to receive(:update).and_return(false)
-      patch income_path(income), params: update_params
-      expect(response).to have_http_status(:unprocessable_entity)
+    context "無効なパラメータの場合" do
+      it "更新されず、422を返す" do
+        patch income_path(income), params: { income: { monthly_income: -1 } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 
   describe "DELETE /destroy" do
-    it "削除成功の場合は、302を返す" do
-      delete income_path(income)
-      expect(response).to have_http_status(:found)
+    context "データが存在する場合" do
+      it "削除成功し、302を返す" do
+        delete income_path(income)
+        expect(response).to have_http_status(:found)
+      end
     end
 
-    it "削除失敗の場合は、404を返す" do
-      delete income_path(-1) # 存在しないID
-      expect(response).to have_http_status(:not_found) # 404
+    context "データが存在しない場合" do
+      it "削除失敗し、404を返す" do
+        delete income_path(-1) # 存在しないID
+        expect(response).to have_http_status(:not_found) # 404
+      end
     end
   end
 end


### PR DESCRIPTION
# 概要
1. incomeフォームの改善。
2. income_reqest_specの改善。

# 行ったこと
1. incomeフォームの送信先をRailsが自動で切り替えを行う仕様に変更し、条件分岐を削除。
  form_with model: incomeにすることで、「新規ならcreate」が、「編集ならupdate」が自動的に呼ばれる。
2. reqest_specの記述位置変更とcontextの追加。