### PR TITLE
feat: add expense edit_form, button, error_message

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,28 +1,43 @@
 class ExpensesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_latest_expense, only: [ :index, :create_or_update ]
+  before_action :set_latest_expense, only: [ :index, :edit, :update, :create, :destroy ]
+  before_action :set_expense, only: [ :edit, :update, :destroy ]
 
   def index
     @expense = Expense.new
   end
 
-  def create_or_update
-    @expense = current_user.expenses.last || current_user.expenses.build
-
-    @expense.assign_attributes(expense_params)
-    @expense.simulation ||= current_user.simulation # 未設定の場合のみ
+  def create
+    old_expense = current_user.expenses.last
+    @expense = current_user.expenses.build(expense_params)
+    @expense.simulation = current_user.simulation
 
     if @expense.save
-      redirect_to expenses_path, notice: t("message.expense.create_or_update.success")
+      old_expense.destroy if old_expense.present? && old_expense.id != @expense.id
+      redirect_to expenses_path, notice: t("message.expense.create.success")
+    else
+      render_error(@expense.errors.full_messages.join(", "), :unprocessable_entity)
+    end
+  end
+
+  def edit
+    if @expense
+      render :index
+    else
+      render_error(t("message.expense.edit.failure"), :not_found)
+    end
+  end
+
+  def update
+    if @expense.update(expense_params)
+      redirect_to expenses_path, notice: t("message.expense.update.success")
     else
       render_error(@expense.errors.full_messages.join(", "), :unprocessable_entity)
     end
   end
 
   def destroy
-    expense = current_user.expenses.find(params[:id])
-
-    if expense.destroy
+    if @expense.destroy
       redirect_to expenses_path, notice: t("message.expense.destroy.success")
     else
       render_error(t("message.expense.destroy.failure"), :not_found)
@@ -33,6 +48,10 @@ class ExpensesController < ApplicationController
 
   def set_latest_expense
     @latest_expense = current_user.expenses.last
+  end
+
+  def set_expense
+    @expense = current_user.expenses.find(params[:id])
   end
 
   def expense_params

--- a/app/views/expenses/_expense_form.html.erb
+++ b/app/views/expenses/_expense_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: expense, url: create_or_update_expenses_path, local: true do |f| %>
+<%= form_with model: expense, local: true do |f| %>
   <div class="row d-flex justify-content-center">
     <div class="col-md-4 col-lg-3 col-xl-3">
       <%= f.label :housing_expenses, '住居費（家賃orローン）', class: 'form-label' %>
@@ -13,7 +13,10 @@
       <div class="input-group">
         <%=
           f.select :repayment_date,
-          options_for_select([['支払なし', nil]] + (Date.today.year..(Date.today.year + 50)).map { |year| [year, year] }),
+          options_for_select(
+            [['支払なし', nil]] + (Date.today.year..(Date.today.year + 50)).map { |year| [year, year] },
+            expense.repayment_date&.year
+          ),
           {},
           class: 'form-select'
         %>
@@ -47,6 +50,9 @@
   </div>
 
   <div class="mt-3 d-flex justify-content-center">
-    <%= f.submit '追加', class: 'btn btn-outline-primary' %>
+    <%= f.submit expense.persisted? ? '更新' : '追加', class: 'btn btn-outline-primary me-2' %>
+    <% if expense.persisted? %>
+      <%= link_to 'キャンセル', expenses_path, class: 'btn btn-outline-secondary' %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/expenses/_registered_expense.html.erb
+++ b/app/views/expenses/_registered_expense.html.erb
@@ -31,6 +31,7 @@
             <li><strong>その他費用:</strong> <%= expense.other_expenses %>万円</li>
           </ul>
           <div class="mt-2">
+            <%= link_to '編集', edit_expense_path(expense), class: 'btn btn-outline-secondary btn-sm me-2' %>
             <%= link_to '削除', expense_path(expense), class: 'btn btn-outline-danger btn-sm px-1 py-1', data: { turbo_method: :delete } %>
           </div>
         </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,7 +18,7 @@ ja:
       create:
         success: "収入データを追加しました。"
       edit:
-        failure: "収入データが見つかりません。"
+        failure: "収入データありません。"
       update:
         success: "収入データを変更しました。"
         failure: "収入データを変更できませんでした。"
@@ -26,8 +26,13 @@ ja:
         success: "収入データを削除しました。"
         failure: "収入データを削除できませんでした。"
     expense:
-      create_or_update:
+      create:
         success: "支出データを追加しました。"
+      edit:
+        failure: "支出データがありません。"
+      update:
+        success: "支出データを変更しました。"
+        failure: "支出データを変更できませんでした。"
       destroy: 
         success: "支出データを削除しました。"
         failure: "支出データを削除できませんでした。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,17 +27,12 @@ Rails.application.routes.draw do
   resources :dashboard,   only: [ :index ]
   resources :users,       only: [ :show ]
   resources :incomes,     only: [ :index, :create, :edit, :update, :destroy ]
+  resources :expenses,    only: [ :index, :create, :edit, :update, :destroy ]
   resources :user_assets, only: [ :index, :create, :destroy ]
   resources :life_events, only: [ :index, :create, :destroy ]
   resources :life_plans,  only: [ :index ]
   resources :memos,       only: [ :create, :update ]
   resources :news,        only: [ :index ]
-
-  resources :expenses, only: [ :index, :destroy ] do
-    collection do
-      post :create_or_update
-    end
-  end
 
   resource :simulation, only: [] do
     post :update_income_data

--- a/spec/requests/expenses_spec.rb
+++ b/spec/requests/expenses_spec.rb
@@ -19,31 +19,97 @@ RSpec.describe "Expenses", type: :request do
     end
   end
 
-  describe "POST /create_or_update" do
-    context "正しいフォーム入力で保存/更新が成功した場合" do
-      it "302を返す" do
-        post create_or_update_expenses_path, params: { expense: valid_params }
-        expect(response).to have_http_status(:found)  # 302
+  describe "POST /create" do
+    context "既にデータがある状態で新規作成する場合" do
+      it "新しいデータ作成後、古いデータが削除され、302を返す" do
+        old_expense = create(:expense, user: user, simulation: simulation)
+        post expenses_path, params: { expense: valid_params }
+
+        expect(user.expenses.count).to eq(1)                  # 保存済みデータが1件(新しいデータ)のみとなることを期待
+        expect(Expense.find_by(id: old_expense.id)).to be_nil # 古いデータが削除されたことを確認
+        expect(response).to have_http_status(:found)          # 302
       end
     end
 
-    context "不正なフォーム入力で保存/更新が失敗した場合" do
-      it "402を返す" do
-        post create_or_update_expenses_path, params: { expense: invalid_params }
-        expect(response).to have_http_status(:unprocessable_entity)  # 422
+    context "データが存在しない状態で新規作成する場合" do
+      it "正常にデータが1件作成される" do
+        post expenses_path, params: { expense: valid_params }
+
+        expect(user.expenses.count).to eq(1)                  # 保存済みデータが1件(新しいデータ)のみとなることを期待
+        expect(response).to have_http_status(:found)          # 302
+      end
+    end
+
+    context "無効なフォーム入力の場合" do
+      it "作成失敗し、422を返す" do
+        post expenses_path, params: { expense: invalid_params }
+        expect(response).to have_http_status(:unprocessable_entity) # 422
+      end
+    end
+  end
+
+  describe "GET /edit" do
+    context "データが存在する場合" do
+      it "編集フォームを表示し、200を返す" do
+        get edit_expense_path(expense)
+        expect(response).to have_http_status(:success) # 200
+      end
+    end
+
+    context "データが存在しない場合" do
+      it "404を返す" do
+        get edit_expense_path(-1) # 存在しないID
+        expect(response).to have_http_status(:not_found) # 404
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    let(:update_params) do
+      {
+        housing_expenses: 5.5,
+        repayment_date: Date.new(2040, 1, 1),
+        living_expenses: 3.2,
+        monthly_premiums: 1.8,
+        other_expenses: 0.5
+      }
+    end
+
+    context "有効なパラメータの場合" do
+      it "更新され、302を返す" do
+        patch expense_path(expense), params: { expense: update_params }
+        expect(response).to have_http_status(:found)
+
+        expense.reload
+        expect(expense.housing_expenses).to eq(5.5)
+        expect(expense.repayment_date).to eq(Date.new(2040, 1, 1))
+        expect(expense.living_expenses).to eq(3.2)
+        expect(expense.monthly_premiums).to eq(1.8)
+        expect(expense.other_expenses).to eq(0.5)
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      it "更新されず、422を返す" do
+        patch expense_path(expense), params: { expense: { housing_expenses: -1 } }
+        expect(response).to have_http_status(:unprocessable_entity) # 422
       end
     end
   end
 
   describe "DELETE /destroy" do
-    it "削除成功の場合、302を返す" do
-      delete expense_path(expense)
-      expect(response).to have_http_status(:found)
+    context "データが存在する場合" do
+      it "削除成功し、302を返す" do
+        delete expense_path(expense)
+        expect(response).to have_http_status(:found)
+      end
     end
 
-    it "削除失敗の場合、404を返す" do
-      delete expense_path(-1) # 存在しないID
-      expect(response).to have_http_status(:not_found) # 404
+    context "データが存在しない場合" do
+      it "削除失敗し、404を返す" do
+        delete expense_path(-1) # 存在しないID
+        expect(response).to have_http_status(:not_found) # 404
+      end
     end
   end
 end


### PR DESCRIPTION
# 概要
登録した支出情報に編集ボタンを持たせ、任意の情報を更新できる機能を追加。

# 背景
- issue番号：[#475](https://github.com/1068haruto/scenapla/issues/475)

# 行ったこと
- expenses_controller.rbに編集と更新のアクションを追加。
- 上記アクションのルーティング追加。
- 登録フォームに編集モードを追加。
- リクエストスペック追加。