### PR TITLE
feat: edit_form for user_asset

### DIFF
--- a/app/controllers/user_assets_controller.rb
+++ b/app/controllers/user_assets_controller.rb
@@ -1,9 +1,9 @@
 class UserAssetsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_user_assets, only: [ :index, :create, :destroy ]
+  before_action :set_user_assets, only: [ :index, :create, :edit, :update, :destroy ]
+  before_action :set_user_asset, only: [ :edit, :update, :destroy ]
 
   def index
-    @user_assets = current_user.user_assets
     @user_asset = UserAsset.new
   end
 
@@ -18,10 +18,24 @@ class UserAssetsController < ApplicationController
     end
   end
 
-  def destroy
-    user_asset = current_user.user_assets.find(params[:id])
+  def edit
+    if @user_asset
+      render :index
+    else
+      render_error(t("message.user_assets.edit.failure"), :not_found)
+    end
+  end
 
-    if user_asset.destroy
+  def update
+    if @user_asset.update(user_asset_params)
+      redirect_to user_assets_path, notice: t("message.user_asset.update.success")
+    else
+      render_error(@user_asset.errors.full_messages.join(", "), :unprocessable_entity)
+    end
+  end
+
+  def destroy
+    if @user_asset.destroy
       redirect_to user_assets_path, notice: t("message.user_asset.destroy.success")
     else
       render_error(t("message.user_assets.destroy.failure"), :not_found)
@@ -32,6 +46,10 @@ class UserAssetsController < ApplicationController
 
   def set_user_assets
     @user_assets = current_user.user_assets
+  end
+
+  def set_user_asset
+    @user_asset = current_user.user_assets.find(params[:id])
   end
 
   def user_asset_params

--- a/app/views/user_assets/_registered_user_asset.html.erb
+++ b/app/views/user_assets/_registered_user_asset.html.erb
@@ -26,13 +26,10 @@
           <li><strong>総額:</strong><%= user_asset.amount %>万円</li>
           <li><strong>利回り:</strong><%= user_asset.return_rate.present? ? "#{user_asset.return_rate}%" : 'なし' %></li>
         </ul>
+
         <div class="mt-2">
-          <%=
-            link_to '削除',
-            user_asset_path(user_asset),
-            class: 'btn btn-outline-danger btn-sm px-1 py-1',
-            data: { turbo_method: :delete }
-          %>
+          <%= link_to '編集', edit_user_asset_path(user_asset), class: 'btn btn-outline-secondary btn-sm me-2' %>
+          <%= link_to '削除', user_asset_path(user_asset), class: 'btn btn-outline-danger btn-sm px-1 py-1', data: { turbo_method: :delete } %>
         </div>
       </div>
     </div>

--- a/app/views/user_assets/_user_asset_form.html.erb
+++ b/app/views/user_assets/_user_asset_form.html.erb
@@ -34,6 +34,9 @@
 	</div>
 
   <div class="mt-3 d-flex justify-content-center">
-    <%= f.submit '追加', class: 'btn btn-outline-primary' %>
+    <%= f.submit user_asset.persisted? ? '更新' : '追加', class: 'btn btn-outline-primary me-2' %>
+    <% if user_asset.persisted? %>
+      <%= link_to 'キャンセル', user_assets_path, class: 'btn btn-outline-secondary' %>
+    <% end %>
   </div>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,7 +21,6 @@ ja:
         failure: "収入データありません。"
       update:
         success: "収入データを変更しました。"
-        failure: "収入データを変更できませんでした。"
       destroy: 
         success: "収入データを削除しました。"
         failure: "収入データを削除できませんでした。"
@@ -32,13 +31,16 @@ ja:
         failure: "支出データがありません。"
       update:
         success: "支出データを変更しました。"
-        failure: "支出データを変更できませんでした。"
       destroy: 
         success: "支出データを削除しました。"
         failure: "支出データを削除できませんでした。"
     user_asset:
       create:
         success: "資産データを追加しました。"
+      edit:
+        failure: "資産データがありません。"
+      update:
+        success: "資産データを変更しました。"
       destroy: 
         success: "資産データを削除しました。"
         failure: "資産データを削除できませんでした。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   resources :users,       only: [ :show ]
   resources :incomes,     only: [ :index, :create, :edit, :update, :destroy ]
   resources :expenses,    only: [ :index, :create, :edit, :update, :destroy ]
-  resources :user_assets, only: [ :index, :create, :destroy ]
+  resources :user_assets, only: [ :index, :create, :edit, :update, :destroy ]
   resources :life_events, only: [ :index, :create, :destroy ]
   resources :life_plans,  only: [ :index ]
   resources :memos,       only: [ :create, :update ]

--- a/spec/requests/user_assets_spec.rb
+++ b/spec/requests/user_assets_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe "UserAssets", type: :request do
   let!(:simulation) { create(:simulation, user: user) }
   let!(:user_asset) { create(:user_asset, user: user, simulation: simulation) }
 
+  # パラメータ
   let(:valid_params) { attributes_for(:user_asset) }
-  let(:invalid_params) { { amount: nil } }
+  let(:valid_params_for_update) { { amount: 20 } }
+  let(:invalid_params) { { amount: -20 } }
 
   before do
     sign_in user
@@ -20,32 +22,67 @@ RSpec.describe "UserAssets", type: :request do
   end
 
   describe "POST /create" do
-    context "正しいフォーム入力で保存成功した場合" do
-      it "user_assets_pathへリダイレクトし302を返す" do
+    context "有効なパラメータの場合" do
+      it "作成成功し、302を返す" do
         post user_assets_path, params: { user_asset: valid_params }
         expect(response).to have_http_status(:found) # 302
       end
     end
 
-    context "不正フォーム入力で保存失敗した場合" do
-      it "422を返す" do
+    context "無効なパラメータの場合" do
+      it "作成失敗し、422を返す" do
         post user_assets_path, params: { user_asset: invalid_params }
         expect(response).to have_http_status(:unprocessable_entity) # 422
       end
     end
   end
 
+  describe "GET /edit" do
+    context "編集したいデータが存在する場合" do
+      it "編集フォームを表示し、200を返す" do
+        get edit_user_asset_path(user_asset)
+        expect(response).to have_http_status(:success) # 200
+      end
+    end
+
+    context "編集したいデータが存在しない場合" do
+      it "編集フォームを表示せず、404を返す" do
+        get edit_user_asset_path(-1) # 存在しないID
+        expect(response).to have_http_status(:not_found) # 404
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "有効なパラメータの場合" do
+      it "更新成功し、302を返す" do
+        patch user_asset_path(user_asset), params: { user_asset: valid_params_for_update }
+        expect(response).to have_http_status(:found) # 302
+
+        user_asset.reload
+        expect(user_asset.amount).to eq 20
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      it "更新失敗し、422を返す" do
+        patch user_asset_path(user_asset), params: { user_asset: invalid_params }
+        expect(response).to have_http_status(:unprocessable_entity) # 422
+      end
+    end
+  end
+
   describe "DELETE /destroy" do
-    context "既存データがあり、削除が成功した場合" do
-      it "user_assets_pathへリダイレクトし302を返す" do
+    context "削除したいデータが存在する場合" do
+      it "削除成功し、302を返す" do
         delete user_asset_path(user_asset)
         expect(response).to have_http_status(:found) # 302
       end
     end
 
-    context "既存データがなく、削除ができない場合" do
-      it "404を返す" do
-        delete user_asset_path(-1) # 存在しないIDを指定
+    context "削除したいデータが存在しない場合" do
+      it "削除失敗し、404を返す" do
+        delete user_asset_path(-1) # 存在しないID
         expect(response).to have_http_status(:not_found) # 404
       end
     end


### PR DESCRIPTION
# 概要
登録した資産情報に編集ボタンを持たせ、任意の情報を更新できる機能を追加。

# 背景
- issue番号：[#476](https://github.com/1068haruto/scenapla/issues/476)

# 主な変更点
- user_assets_controller.rbに編集と更新のアクションを追加。
- 上記アクションのルーティング追加。
- 登録フォームに編集モードを追加。
- リクエストスペック追加。