### PR TITLE
feat: life_events edit_form

### DIFF
--- a/app/controllers/life_events_controller.rb
+++ b/app/controllers/life_events_controller.rb
@@ -1,6 +1,7 @@
 class LifeEventsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_life_events, only: [ :index, :create, :destroy ]
+  before_action :set_life_events, only: [ :index, :create, :edit, :update, :destroy ]
+  before_action :set_life_event, only: [ :edit, :update, :destroy ]
 
   def index
     @life_event = LifeEvent.new
@@ -17,10 +18,24 @@ class LifeEventsController < ApplicationController
     end
   end
 
-  def destroy
-    life_event = current_user.life_events.find(params[:id])
+  def edit
+    if @life_event
+      render :index
+    else
+      render_error(t("message.life_event.edit.failure"), :not_found)
+    end
+  end
 
-    if life_event.destroy
+  def update
+    if @life_event.update(life_event_params)
+      redirect_to life_events_path, notice: t("message.life_event.update.success")
+    else
+      render_error(@life_event.errors.full_messages.join(", "), :unprocessable_entity)
+    end
+  end
+
+  def destroy
+    if @life_event.destroy
       redirect_to life_events_path, notice: t("message.life_event.destroy.success")
     else
       render_error(t("message.life_event.destroy.failure"), :not_found)
@@ -31,6 +46,10 @@ class LifeEventsController < ApplicationController
 
   def set_life_events
     @life_events = current_user.life_events.order(event_date: :asc)
+  end
+
+  def set_life_event
+    @life_event = current_user.life_events.find(params[:id])
   end
 
   def life_event_params

--- a/app/models/life_event.rb
+++ b/app/models/life_event.rb
@@ -4,6 +4,8 @@ class LifeEvent < ApplicationRecord
 
   enum event_type: { 現実: 0, 理想: 1 }
 
+  PAYMENT_PERIOD_OPTIONS = (1..10).to_a.freeze
+
   validates :user_id, :simulation_id, presence: true
   validates :event_type, :event_date, :title, :payment_period, presence: true
   validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/views/life_events/_life_event_form.html.erb
+++ b/app/views/life_events/_life_event_form.html.erb
@@ -2,7 +2,13 @@
 	<div class="row d-flex justify-content-center">
 		<div class="col-md-3 col-lg-3 col-xl-2">
 			<%= f.label :event_type, 'イベントタイプ', class: 'form-label' %>
-			<%= f.select :event_type, [['現実', 0], ['理想', 1]], { selected: 0 }, class: 'form-select', autofocus: true %>
+			<%=
+				f.select :event_type,
+				[['現実', 0], ['理想', 1]],
+				{ selected: life_event.event_type_before_type_cast },
+				class: 'form-select',
+				autofocus: true
+			%>
 		</div>
 
 		<div class="col-md-3 col-lg-3 col-xl-2">
@@ -10,7 +16,10 @@
 			<div class="input-group">
 				<%=
 					f.select :event_date,
-					options_for_select((Date.today.year..(Date.today.year + 50)).map { |year| [year, year] }),
+					options_for_select(
+						(Date.today.year..(Date.today.year + 50)).map { |year| [year, year] },
+						life_event.event_date&.year
+					),
 					{},
 					class: 'form-select'
 				%>
@@ -34,13 +43,21 @@
 		<div class="col-md-3 col-lg-2 col-xl-2">
 			<%= f.label :payment_period, '支払期間', class: 'form-label' %>
 			<div class="input-group">
-				<%= f.select :payment_period, (1..10).map { |i| [i.to_s, i] }, {selected: 1 }, class: 'form-select' %>
+				<%=
+					f.select :payment_period,
+  				LifeEvent::PAYMENT_PERIOD_OPTIONS.map { |n| ["#{n}", n] },
+  				{},
+  				class: 'form-select'
+				%>
 				<span class="input-group-text">年間</span>
 			</div>
 		</div>
 	</div>
 
 	<div class="mt-3 d-flex justify-content-center">
-		<%= f.submit '追加', class: 'btn btn-outline-primary' %>
+		<%= f.submit life_event.persisted? ? '更新' : '追加', class: 'btn btn-outline-primary me-2' %>
+    <% if life_event.persisted? %>
+      <%= link_to 'キャンセル', life_events_path, class: 'btn btn-outline-secondary' %>
+    <% end %>
 	</div>
 <% end %>

--- a/app/views/life_events/_registered_life_event.html.erb
+++ b/app/views/life_events/_registered_life_event.html.erb
@@ -28,12 +28,8 @@
       </ul>
       <% if show_delete_button %>
         <div class="mt-2">
-          <%=
-            link_to '削除',
-            life_event_path(life_event),
-            class: 'btn btn-outline-danger btn-sm px-1 py-1',
-            data: { turbo_method: :delete }
-          %>
+          <%= link_to '編集', edit_life_event_path(life_event), class: 'btn btn-outline-secondary btn-sm me-2' %>
+          <%= link_to '削除', life_event_path(life_event), class: 'btn btn-outline-danger btn-sm px-1 py-1', data: { turbo_method: :delete } %>
         </div>
       <% end %>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -47,6 +47,10 @@ ja:
     life_event:
       create:
         success: "ライフイベントデータを追加しました。"
+      edit:
+        failure: "ライフイベントデータがありません。"
+      update:
+        success: "ライフイベントデータを変更しました。"
       destroy: 
         success: "ライフイベントデータを削除しました。"
         failure: "ライフイベントデータを削除できませんでした。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   resources :incomes,     only: [ :index, :create, :edit, :update, :destroy ]
   resources :expenses,    only: [ :index, :create, :edit, :update, :destroy ]
   resources :user_assets, only: [ :index, :create, :edit, :update, :destroy ]
-  resources :life_events, only: [ :index, :create, :destroy ]
+  resources :life_events, only: [ :index, :create, :edit, :update, :destroy ]
   resources :life_plans,  only: [ :index ]
   resources :memos,       only: [ :create, :update ]
   resources :news,        only: [ :index ]

--- a/spec/requests/life_events_spec.rb
+++ b/spec/requests/life_events_spec.rb
@@ -5,46 +5,83 @@ RSpec.describe "LifeEvents", type: :request do
   let!(:simulation) { create(:simulation, user: user) }
   let!(:life_event) { create(:life_event, user: user, simulation: simulation) }
 
-  let(:valid_params) { attributes_for(:life_event) } # 有効なデータ
-  let(:invalid_params) { { event_date: nil } }  # 無効なデータ
+  # パラメータ
+  let(:valid_params) { attributes_for(:life_event) }
+  let(:invalid_params) { { amount: nil } }
+  let(:valid_params_for_update) { { amount: 20 } }
 
   before do
     sign_in user
   end
 
   describe "GET /index" do
-    it "ページを表示し200を返す" do
+    it "ページを表示し、200を返す" do
       get life_events_path
       expect(response).to have_http_status(:success)  # 200
     end
   end
 
   describe "POST /create" do
-    context "有効なフォーム入力の場合" do
-      it "life_events_pathにリダイレクトし302を返す" do
+    context "有効なパラメータの場合" do
+      it "作成失敗し、302を返す" do
         post life_events_path, params: { life_event: valid_params }
         expect(response).to have_http_status(:found)  # 302
       end
     end
 
-    context "不正なフォーム入力の場合" do
-      it "422を返す" do
+    context "無効なパラメータの場合" do
+      it "作成失敗し、422を返す" do
         post life_events_path, params: { life_event: invalid_params }
         expect(response).to have_http_status(:unprocessable_entity)  # 422
       end
     end
   end
 
+  describe "GET /edit" do
+    context "編集したいデータが存在する場合" do
+      it "編集フォームを表示し、200を返す" do
+        get edit_life_event_path(life_event)
+        expect(response).to have_http_status(:success) # 200
+      end
+    end
+
+    context "編集したいデータがしない場合" do
+      it "編集フォームを表示せず、404を返す" do
+        get edit_life_event_path(-1)                     # 存在しないID
+        expect(response).to have_http_status(:not_found) # 404
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "有効なパラメータの場合" do
+      it "更新成功し、302を返す" do
+        patch life_event_path(life_event), params: { life_event: valid_params_for_update }
+        expect(response).to have_http_status(:found) # 302
+
+        life_event.reload
+        expect(life_event.amount).to eq 20
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      it "更新失敗し、422を返す" do
+        patch life_event_path(life_event), params: { life_event: invalid_params }
+        expect(response).to have_http_status(:unprocessable_entity) # 422
+      end
+    end
+  end
+
   describe "DELETE /destroy" do
-    context "イベントデータがあり、削除成功した場合" do
-      it "life_events_pathにリダイレクトし302を返す" do
+    context "削除したいデータが存在する場合" do
+      it "削除成功し、302を返す" do
         delete life_event_path(life_event)
         expect(response).to have_http_status(:found)  # 302
       end
     end
 
-    context "イベントデータがなく、削除失敗した場合" do
-      it "404を返す" do
+    context "削除したいデータが存在しない場合" do
+      it "削除失敗し、404を返す" do
         delete life_event_path(-1) # 存在しないID
         expect(response).to have_http_status(:not_found)  # 404
       end


### PR DESCRIPTION
# 概要
life_eventデータの編集機能の設置。

# 背景
issue番号：[#477](https://github.com/1068haruto/scenapla/issues/477)

# 主な変更点
- life_events_controller.rbに編集と更新のアクションを追加。
- 上記アクションのルーティング追加。
- 登録フォームに編集モードを追加。
- リクエストスペック追加。