### PR TITLE
update: TAX_RATE from 20% to 20.315%

### DIFF
--- a/app/models/user_asset.rb
+++ b/app/models/user_asset.rb
@@ -3,7 +3,7 @@ class UserAsset < ApplicationRecord
   belongs_to :simulation
 
   AGE_LIMIT = 70
-  TAX_RATE = 0.2
+  TAX_RATE = 0.20315  # 20.315％（所得税等15.315％、住民税５％）
   ASSET_TYPE_IS_OTHER = "投資_その他"
 
   enum person_type: { 本人: 0, 配偶者: 1 }
@@ -43,7 +43,7 @@ class UserAsset < ApplicationRecord
   # 1年目の資産設定 & 2年目以降の計算メソッド呼び出し
   def self.calculate_asset_projection(asset, yearly_totals, current_year, year_at_seventy)
     amount = asset.amount
-    rate = asset.return_rate.to_f / 100.0  # 利回りの小数変換
+    rate = asset.return_rate.to_f / 100.0  # 利回りの小数変換（例　10%の場合：0.1）
 
     yearly_totals[current_year] += amount  # 1年目の資産(利回り計算なし)
 
@@ -62,7 +62,7 @@ class UserAsset < ApplicationRecord
   # 利益計算
   def self.calculate_profit(amount, rate, asset_type)
     profit = amount * rate
-    profit -= profit * TAX_RATE if asset_type == ASSET_TYPE_IS_OTHER  # 資産種類が4の場合、利益の20%を課税
+    profit -= profit * TAX_RATE if asset_type == ASSET_TYPE_IS_OTHER  # 資産種類が4の場合、利益の20.315%を課税
     profit
   end
 

--- a/spec/models/user_asset_spec.rb
+++ b/spec/models/user_asset_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe UserAsset, type: :model do
   end
 
   describe '定数テスト' do
-    it 'AGE_LIMITは70である' do
+    it 'AGE_LIMITは、「70」である' do
       expect(described_class::AGE_LIMIT).to eq(70)
     end
 
-    it 'TAX_RATEは12である' do
-      expect(described_class::TAX_RATE).to eq(0.2)
+    it 'TAX_RATEは、「0.20315」である' do
+      expect(described_class::TAX_RATE).to eq(0.20315)
     end
 
-    it 'ASSET_TYPE_IS_OTHERは12である' do
+    it 'ASSET_TYPE_IS_OTHERは、「12」である' do
       expect(described_class::ASSET_TYPE_IS_OTHER).to eq("投資_その他")
     end
   end
@@ -202,7 +202,7 @@ RSpec.describe UserAsset, type: :model do
     describe '.calculate_profit' do
       amount = 10
 
-      it '利回りが0の場合、利益は0となる' do
+      it '利回りが0の場合、利益は0とする' do
         rate = 0
         asset_type = "預金"
         profit = described_class.calculate_profit(amount, rate, asset_type)
@@ -220,7 +220,7 @@ RSpec.describe UserAsset, type: :model do
         rate = 0.1
         asset_type = "投資_その他"
         profit = described_class.calculate_profit(amount, rate, asset_type)
-        expect(profit).to eq(0.8) # 10 * 0.1 * 0.8
+        expect(profit).to eq(0.7968500000000001) # 10 * 0.1 = 1, 1 - (1 * 0.20315) = 0.7968500...1
       end
     end
 


### PR DESCRIPTION
# 概要
資産計算において、「その他＿投資」の運用利益にかかる税率を「20%」から「20.315%」に変更。

# 背景
issue番号: [#480](https://github.com/1068haruto/scenapla/issues/480)

# 主な変更点
1. UserAssetモデル内の、定数の値（税率）を変更。
2. 上記変更に伴うrspecの修正。